### PR TITLE
build: fix the build of `unified-bridge` on zkvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7077,19 +7077,13 @@ dependencies = [
  "agglayer-primitives",
  "agglayer-tries",
  "arbitrary",
- "bincode",
  "hex",
  "hex-literal",
  "rand 0.9.0",
  "rs_merkle",
  "serde",
- "serde_json",
  "serde_with",
- "sp1-core-machine",
- "sp1-prover",
- "sp1-sdk",
  "thiserror 2.0.12",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/unified-bridge/Cargo.toml
+++ b/crates/unified-bridge/Cargo.toml
@@ -13,20 +13,14 @@ agglayer-primitives.workspace = true
 agglayer-tries.workspace = true
 
 arbitrary = { workspace = true, optional = true }
-bincode.workspace = true
 hex-literal = "0.4"
-hex.workspace = true
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["arbitrary_precision"] }
 serde_with = { version = "3" }
-sp1-core-machine.workspace = true
-sp1-prover.workspace = true
-sp1-sdk.workspace = true
 thiserror.workspace = true
-tiny-keccak = { version = "2.0", features = ["keccak"] }
 
 [dev-dependencies]
 agglayer-primitives = { workspace = true, features = ["testutils"] }
+hex.workspace = true
 rand = "0.9.0"
 rs_merkle = { version = "1.4", default-features = false }
 


### PR DESCRIPTION
Pruned a bunch of unused dependencies from the `unified-bridge` crate.

The problematic one is `sp1-sdk`. It cannot be built for zkvm since it pulls in IO-related functionality through `tokio`. That is not supported inside zkvm.

Also used this as an opportunity to prune a bunch of other unused dependencies.

* unblocks https://github.com/agglayer/agglayer/pull/727

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
