### PR TITLE
feat: introduce fuzzer infra, make everything faster

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,6 @@
 extend = [
     { path = "scripts/make/Makefile.ci.toml" },
+    { path = "scripts/make/Makefile.fuzz.toml" },
     { path = "scripts/make/Makefile.proto.toml" },
 ]
 

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/address.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/address.rs
@@ -7,12 +7,14 @@ use crate::v1;
 impl TryFrom<v1::FixedBytes20> for Address {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::FixedBytes20) -> Result<Self, Self::Error> {
         Ok(Address::from(<[u8; 20]>::try_from(value)?))
     }
 }
 
 impl From<Address> for v1::FixedBytes20 {
+    #[inline]
     fn from(value: Address) -> Self {
         v1::FixedBytes20 {
             value: Bytes::copy_from_slice(&value.0 .0),

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/aggchain_data.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/aggchain_data.rs
@@ -7,6 +7,7 @@ use prost::bytes::Bytes;
 use super::Error;
 use crate::v1;
 
+#[inline]
 fn sp1v4_bincode_options() -> impl bincode::Options {
     bincode::DefaultOptions::new()
         .with_big_endian()

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/bridge_exit.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/bridge_exit.rs
@@ -30,6 +30,7 @@ impl TryFrom<v1::BridgeExit> for BridgeExit {
 }
 
 impl From<BridgeExit> for v1::BridgeExit {
+    #[inline]
     fn from(value: BridgeExit) -> Self {
         v1::BridgeExit {
             leaf_type: match value.leaf_type {

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/bytes.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/bytes.rs
@@ -4,6 +4,7 @@ use crate::v1;
 impl TryFrom<v1::FixedBytes20> for [u8; 20] {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::FixedBytes20) -> Result<Self, Self::Error> {
         (&*value.value).try_into().map_err(|_| {
             Error::invalid_data(format!("expected 20 bytes, got {}", value.value.len()))
@@ -14,6 +15,7 @@ impl TryFrom<v1::FixedBytes20> for [u8; 20] {
 impl TryFrom<v1::FixedBytes32> for [u8; 32] {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::FixedBytes32) -> Result<Self, Self::Error> {
         (&*value.value).try_into().map_err(|_| {
             Error::invalid_data(format!("expected 32 bytes, got {}", value.value.len()))

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/claim.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/claim.rs
@@ -6,6 +6,7 @@ use crate::v1;
 impl TryFrom<v1::ClaimFromMainnet> for ClaimFromMainnet {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::ClaimFromMainnet) -> Result<Self, Self::Error> {
         Ok(ClaimFromMainnet {
             proof_leaf_mer: required_field!(value, proof_leaf_mer),
@@ -16,6 +17,7 @@ impl TryFrom<v1::ClaimFromMainnet> for ClaimFromMainnet {
 }
 
 impl From<ClaimFromMainnet> for v1::ClaimFromMainnet {
+    #[inline]
     fn from(value: ClaimFromMainnet) -> Self {
         v1::ClaimFromMainnet {
             proof_leaf_mer: Some(value.proof_leaf_mer.into()),
@@ -28,6 +30,7 @@ impl From<ClaimFromMainnet> for v1::ClaimFromMainnet {
 impl TryFrom<v1::ClaimFromRollup> for ClaimFromRollup {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::ClaimFromRollup) -> Result<Self, Self::Error> {
         Ok(ClaimFromRollup {
             proof_leaf_ler: required_field!(value, proof_leaf_ler),
@@ -39,6 +42,7 @@ impl TryFrom<v1::ClaimFromRollup> for ClaimFromRollup {
 }
 
 impl From<ClaimFromRollup> for v1::ClaimFromRollup {
+    #[inline]
     fn from(value: ClaimFromRollup) -> Self {
         v1::ClaimFromRollup {
             proof_leaf_ler: Some(value.proof_leaf_ler.into()),
@@ -52,6 +56,7 @@ impl From<ClaimFromRollup> for v1::ClaimFromRollup {
 impl TryFrom<v1::imported_bridge_exit::Claim> for Claim {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::imported_bridge_exit::Claim) -> Result<Self, Self::Error> {
         Ok(match value {
             v1::imported_bridge_exit::Claim::Mainnet(claim_from_mainnet) => {
@@ -71,6 +76,7 @@ impl TryFrom<v1::imported_bridge_exit::Claim> for Claim {
 }
 
 impl From<Claim> for v1::imported_bridge_exit::Claim {
+    #[inline]
     fn from(value: Claim) -> Self {
         match value {
             Claim::Mainnet(claim_from_mainnet) => {

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/digest.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/digest.rs
@@ -7,12 +7,14 @@ use crate::v1;
 impl TryFrom<v1::FixedBytes32> for Digest {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::FixedBytes32) -> Result<Self, Self::Error> {
         Ok(Digest::from(<[u8; 32]>::try_from(value)?))
     }
 }
 
 impl From<Digest> for v1::FixedBytes32 {
+    #[inline]
     fn from(value: Digest) -> Self {
         v1::FixedBytes32 {
             value: Bytes::copy_from_slice(&value.0),

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/error.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/error.rs
@@ -19,6 +19,7 @@ pub enum ErrorKind {
 }
 
 impl fmt::Display for ErrorKind {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorKind::InvalidData => {
@@ -41,6 +42,7 @@ pub struct Error {
 }
 
 impl fmt::Display for Error {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.field.is_empty() {
             write!(f, "{}: ", self.field_str())?;
@@ -50,6 +52,7 @@ impl fmt::Display for Error {
 }
 
 impl Error {
+    #[inline]
     pub fn missing_field(f: &'static str) -> Self {
         Error {
             kind: ErrorKind::MissingField,
@@ -59,6 +62,7 @@ impl Error {
         }
     }
 
+    #[inline]
     pub fn invalid_data(m: String) -> Self {
         Error {
             kind: ErrorKind::InvalidData,
@@ -68,12 +72,14 @@ impl Error {
         }
     }
 
+    #[inline]
     pub fn inside_field(mut self, f: &'static str) -> Self {
         self.field.push(f);
         self.field.rotate_right(1);
         self
     }
 
+    #[inline]
     pub fn serializing_proof(e: bincode::Error) -> Self {
         Error {
             kind: ErrorKind::InvalidData,
@@ -83,6 +89,7 @@ impl Error {
         }
     }
 
+    #[inline]
     pub fn deserializing_proof(e: bincode::Error) -> Self {
         Error {
             kind: ErrorKind::InvalidData,
@@ -92,6 +99,7 @@ impl Error {
         }
     }
 
+    #[inline]
     pub fn parsing_signature(e: SignatureError) -> Self {
         Error {
             kind: ErrorKind::InvalidData,
@@ -101,14 +109,17 @@ impl Error {
         }
     }
 
+    #[inline]
     pub fn kind(&self) -> ErrorKind {
         self.kind
     }
 
+    #[inline]
     pub fn field(&self) -> &[&'static str] {
         &self.field
     }
 
+    #[inline]
     pub fn field_str(&self) -> String {
         if self.field.is_empty() {
             ".".to_string()
@@ -119,6 +130,7 @@ impl Error {
 }
 
 impl From<&Error> for Vec<FieldViolation> {
+    #[inline]
     fn from(value: &Error) -> Self {
         vec![FieldViolation::new(
             value.field_str(),

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/global_index.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/global_index.rs
@@ -6,12 +6,14 @@ use crate::v1;
 impl TryFrom<v1::FixedBytes32> for GlobalIndex {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::FixedBytes32) -> Result<Self, Self::Error> {
         Ok(GlobalIndex::from(U256::try_from(value)?))
     }
 }
 
 impl From<GlobalIndex> for v1::FixedBytes32 {
+    #[inline]
     fn from(value: GlobalIndex) -> Self {
         <U256 as From<GlobalIndex>>::from(value).into()
     }

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/imported_bridge_exit.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/imported_bridge_exit.rs
@@ -6,6 +6,7 @@ use crate::v1;
 impl TryFrom<v1::ImportedBridgeExit> for ImportedBridgeExit {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::ImportedBridgeExit) -> Result<Self, Self::Error> {
         Ok(ImportedBridgeExit {
             bridge_exit: required_field!(value, bridge_exit),
@@ -16,6 +17,7 @@ impl TryFrom<v1::ImportedBridgeExit> for ImportedBridgeExit {
 }
 
 impl From<ImportedBridgeExit> for v1::ImportedBridgeExit {
+    #[inline]
     fn from(value: ImportedBridgeExit) -> Self {
         v1::ImportedBridgeExit {
             bridge_exit: Some(value.bridge_exit.into()),

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/l1_info_tree_leaf.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/l1_info_tree_leaf.rs
@@ -6,6 +6,7 @@ use crate::v1;
 impl TryFrom<v1::L1InfoTreeLeaf> for L1InfoTreeLeafInner {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::L1InfoTreeLeaf) -> Result<Self, Self::Error> {
         Ok(L1InfoTreeLeafInner {
             global_exit_root: required_field!(value, global_exit_root),
@@ -16,6 +17,7 @@ impl TryFrom<v1::L1InfoTreeLeaf> for L1InfoTreeLeafInner {
 }
 
 impl From<L1InfoTreeLeafInner> for v1::L1InfoTreeLeaf {
+    #[inline]
     fn from(value: L1InfoTreeLeafInner) -> Self {
         v1::L1InfoTreeLeaf {
             global_exit_root: Some(value.global_exit_root.into()),
@@ -28,6 +30,7 @@ impl From<L1InfoTreeLeafInner> for v1::L1InfoTreeLeaf {
 impl TryFrom<v1::L1InfoTreeLeafWithContext> for L1InfoTreeLeaf {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::L1InfoTreeLeafWithContext) -> Result<Self, Self::Error> {
         Ok(L1InfoTreeLeaf {
             l1_info_tree_index: value.l1_info_tree_index,
@@ -39,6 +42,7 @@ impl TryFrom<v1::L1InfoTreeLeafWithContext> for L1InfoTreeLeaf {
 }
 
 impl From<L1InfoTreeLeaf> for v1::L1InfoTreeLeafWithContext {
+    #[inline]
     fn from(value: L1InfoTreeLeaf) -> Self {
         v1::L1InfoTreeLeafWithContext {
             l1_info_tree_index: value.l1_info_tree_index,

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/merkle_proof.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/merkle_proof.rs
@@ -25,6 +25,7 @@ impl TryFrom<v1::MerkleProof> for MerkleProof {
 }
 
 impl From<MerkleProof> for v1::MerkleProof {
+    #[inline]
     fn from(value: MerkleProof) -> Self {
         v1::MerkleProof {
             root: Some(value.root.into()),

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
@@ -8,22 +8,6 @@ use prost::Message;
 use super::Error;
 use crate::v1;
 
-#[cfg(fuzzing)]
-pub mod fuzzing_workarounds {
-    // TODO: these all should be in sp1 upstream, but they're not marked as #[used]
-    // and so disappear with optimizations
-    #[no_mangle]
-    pub extern "C" fn read_vec_raw() {
-        unimplemented!("SP1 workaround, should never be called")
-    }
-    #[no_mangle]
-    pub extern "C" fn _end() {
-        unimplemented!("SP1 workaround, should never be called")
-    }
-    #[used]
-    static _USED: [extern "C" fn(); 2] = [read_vec_raw, _end];
-}
-
 #[rstest::rstest]
 #[case::error("no_proof", Error::missing_field("proof"))]
 #[case::error("bad_data", Error::invalid_data("invalid value".to_owned()))]

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/token_info.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/token_info.rs
@@ -6,6 +6,7 @@ use crate::v1;
 impl TryFrom<v1::TokenInfo> for TokenInfo {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::TokenInfo) -> Result<Self, Self::Error> {
         Ok(TokenInfo {
             origin_network: value.origin_network.into(),
@@ -15,6 +16,7 @@ impl TryFrom<v1::TokenInfo> for TokenInfo {
 }
 
 impl From<TokenInfo> for v1::TokenInfo {
+    #[inline]
     fn from(value: TokenInfo) -> Self {
         v1::TokenInfo {
             origin_network: *value.origin_network,

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/u256.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/u256.rs
@@ -7,12 +7,14 @@ use crate::v1;
 impl TryFrom<v1::FixedBytes32> for U256 {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: v1::FixedBytes32) -> Result<Self, Self::Error> {
         Ok(U256::from_be_bytes(<[u8; 32]>::try_from(value)?))
     }
 }
 
 impl From<U256> for v1::FixedBytes32 {
+    #[inline]
     fn from(value: U256) -> Self {
         v1::FixedBytes32 {
             value: Bytes::copy_from_slice(&value.to_be_bytes::<32>()),

--- a/crates/agglayer-primitives/src/digest.rs
+++ b/crates/agglayer-primitives/src/digest.rs
@@ -12,30 +12,36 @@ pub struct Digest(pub [u8; 32]);
 
 impl Deref for Digest {
     type Target = [u8; 32];
+
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl AsRef<[u8]> for Digest {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
 }
 
 impl fmt::Display for Digest {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:#x}", self)
     }
 }
 
 impl fmt::Debug for Digest {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x}", self)
     }
 }
 
 impl fmt::UpperHex for Digest {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             write!(f, "0x")?;
@@ -52,22 +58,26 @@ impl fmt::UpperHex for Digest {
 impl Digest {
     pub const ZERO: Digest = Digest([0u8; 32]);
 
+    #[inline]
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_slice()
     }
 
+    #[inline]
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 }
 
 impl From<[u8; 32]> for Digest {
+    #[inline]
     fn from(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 }
 
 impl fmt::LowerHex for Digest {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if f.alternate() {
             write!(f, "0x")?;
@@ -82,6 +92,7 @@ impl fmt::LowerHex for Digest {
 }
 
 impl<'de> Deserialize<'de> for Digest {
+    #[inline]
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -105,6 +116,7 @@ impl<'de> Deserialize<'de> for Digest {
 }
 
 impl Serialize for Digest {
+    #[inline]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -126,6 +138,7 @@ const DIGEST_FROM_BOOL_FALSE: Digest = Digest([
 ]);
 
 impl FromBool for Digest {
+    #[inline]
     fn from_bool(b: bool) -> Self {
         if b {
             DIGEST_FROM_BOOL_TRUE
@@ -136,6 +149,7 @@ impl FromBool for Digest {
 }
 
 impl FromU256 for Digest {
+    #[inline]
     fn from_u256(u: U256) -> Self {
         Self(u.to_be_bytes())
     }
@@ -143,6 +157,8 @@ impl FromU256 for Digest {
 
 impl TryFrom<&[u8]> for Digest {
     type Error = std::array::TryFromSliceError;
+
+    #[inline]
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         <[u8; 32]>::try_from(value).map(Digest)
     }
@@ -150,12 +166,15 @@ impl TryFrom<&[u8]> for Digest {
 
 impl TryFrom<Vec<u8>> for Digest {
     type Error = std::array::TryFromSliceError;
+
+    #[inline]
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
         Self::try_from(&*value)
     }
 }
 
 impl From<Digest> for Vec<u8> {
+    #[inline]
     fn from(value: Digest) -> Self {
         value.0.to_vec()
     }
@@ -163,6 +182,7 @@ impl From<Digest> for Vec<u8> {
 
 #[cfg(any(test, feature = "testutils"))]
 impl rand::distr::Distribution<Digest> for rand::distr::StandardUniform {
+    #[inline]
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Digest {
         let raw: [u8; 32] = rng.random();
         Digest(raw)

--- a/crates/agglayer-primitives/src/keccak.rs
+++ b/crates/agglayer-primitives/src/keccak.rs
@@ -4,6 +4,7 @@ use tiny_keccak::{Hasher as _, Keccak};
 pub use crate::digest::Digest;
 
 /// Hashes the input data using a Keccak hasher with a 256-bit security level.
+#[inline]
 pub fn keccak256(data: &[u8]) -> Digest {
     let mut hasher = Keccak::v256();
     hasher.update(data);
@@ -16,6 +17,7 @@ pub fn keccak256(data: &[u8]) -> Digest {
 /// Hashes the input items using a Keccak hasher with a 256-bit security level.
 /// Safety: This function should only be called with fixed-size items to avoid
 /// collisions.
+#[inline]
 pub fn keccak256_combine<I, T>(items: I) -> Digest
 where
     I: IntoIterator<Item = T>,
@@ -46,6 +48,7 @@ pub struct Keccak256Hasher;
 impl Hasher for Keccak256Hasher {
     type Digest = Digest;
 
+    #[inline]
     fn merge(left: &Self::Digest, right: &Self::Digest) -> Self::Digest {
         keccak256_combine([left.as_ref(), right.as_ref()])
     }

--- a/crates/agglayer-primitives/src/signature.rs
+++ b/crates/agglayer-primitives/src/signature.rs
@@ -10,46 +10,56 @@ use super::{Address, SignatureError, B256, U256};
 pub struct Signature(PrimitiveSignature);
 
 impl Signature {
+    #[inline]
     pub fn from_signature_and_parity(sig: ecdsa::Signature, v: bool) -> Self {
         PrimitiveSignature::from_signature_and_parity(sig, v).into()
     }
 
+    #[inline]
     pub fn new(r: U256, s: U256, v: bool) -> Self {
         PrimitiveSignature::new(r, s, v).into()
     }
 
+    #[inline]
     pub fn recover_address_from_prehash(&self, prehash: &B256) -> Result<Address, SignatureError> {
         self.0.recover_address_from_prehash(prehash)
     }
 
+    #[inline]
     pub fn as_primitive_signature(&self) -> &PrimitiveSignature {
         &self.0
     }
 
+    #[inline]
     pub fn as_bytes(&self) -> [u8; 65] {
         self.0.as_bytes()
     }
 
+    #[inline]
     pub fn r(&self) -> U256 {
         self.0.r()
     }
 
+    #[inline]
     pub fn s(&self) -> U256 {
         self.0.s()
     }
 
+    #[inline]
     pub fn v(&self) -> bool {
         self.0.v()
     }
 }
 
 impl From<PrimitiveSignature> for Signature {
+    #[inline]
     fn from(ps: PrimitiveSignature) -> Self {
         Self(ps)
     }
 }
 
 impl From<Signature> for PrimitiveSignature {
+    #[inline]
     fn from(value: Signature) -> Self {
         value.0
     }
@@ -58,6 +68,7 @@ impl From<Signature> for PrimitiveSignature {
 impl TryFrom<&[u8]> for Signature {
     type Error = SignatureError;
 
+    #[inline]
     fn try_from(sig: &[u8]) -> Result<Self, Self::Error> {
         sig.try_into().map(Self)
     }
@@ -66,6 +77,7 @@ impl TryFrom<&[u8]> for Signature {
 impl std::str::FromStr for Signature {
     type Err = <PrimitiveSignature as std::str::FromStr>::Err;
 
+    #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         s.parse().map(Self)
     }
@@ -83,18 +95,21 @@ mod compat {
     }
 
     impl Signature {
+        #[inline]
         fn new(r: U256, s: U256, odd_y_parity: bool) -> Self {
             Self { r, s, odd_y_parity }
         }
     }
 
     impl From<super::Signature> for Signature {
+        #[inline]
         fn from(sig: super::Signature) -> Self {
             Self::new(sig.0.r(), sig.0.s(), sig.0.v())
         }
     }
 
     impl From<Signature> for super::Signature {
+        #[inline]
         fn from(sig: Signature) -> Self {
             let Signature { r, s, odd_y_parity } = sig;
             Self::new(r, s, odd_y_parity)

--- a/crates/agglayer-tries/src/node.rs
+++ b/crates/agglayer-tries/src/node.rs
@@ -12,6 +12,7 @@ where
 {
     #[serde_as(as = "_")]
     pub left: H::Digest,
+
     #[serde_as(as = "_")]
     pub right: H::Digest,
 }
@@ -21,6 +22,7 @@ where
     H: Hasher,
     H::Digest: Copy + Serialize + DeserializeOwned,
 {
+    #[inline]
     fn clone(&self) -> Self {
         *self
     }
@@ -38,6 +40,7 @@ where
     H: Hasher,
     H::Digest: Serialize + DeserializeOwned,
 {
+    #[inline]
     pub fn hash(&self) -> H::Digest {
         H::merge(&self.left, &self.right)
     }

--- a/crates/agglayer-tries/src/proof.rs
+++ b/crates/agglayer-tries/src/proof.rs
@@ -9,16 +9,19 @@ pub trait ToBits<const NUM_BITS: usize> {
 }
 
 impl ToBits<8> for u8 {
+    #[inline]
     fn to_bits(&self) -> [bool; 8] {
         std::array::from_fn(|i| (self >> i) & 1 == 1)
     }
 }
 
 impl ToBits<32> for u32 {
+    #[inline]
     fn to_bits(&self) -> [bool; 32] {
         std::array::from_fn(|i| (self >> i) & 1 == 1)
     }
 }
+
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SmtMerkleProof<H, const DEPTH: usize>

--- a/crates/agglayer-tries/src/smt.rs
+++ b/crates/agglayer-tries/src/smt.rs
@@ -21,9 +21,11 @@ where
     /// The SMT root
     #[serde_as(as = "_")]
     pub root: H::Digest,
+
     /// A map from node hash to node
     #[serde_as(as = "HashMap<_, _>")]
     pub tree: HashMap<H::Digest, Node<H>>,
+
     /// `empty_hash_at_height[i]` is the root of an empty Merkle tree of depth
     /// `i`.
     #[serde_as(as = "[_; DEPTH]")]
@@ -35,6 +37,7 @@ where
     H: Hasher,
     H::Digest: Copy + Eq + Hash + Serialize + DeserializeOwned + Default,
 {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
@@ -45,6 +48,7 @@ where
     H: Hasher,
     H::Digest: Copy + Eq + Hash + Serialize + DeserializeOwned,
 {
+    #[inline]
     pub fn new() -> Self
     where
         H::Digest: Default,
@@ -57,6 +61,7 @@ where
         Self::new_with_nodes(root.hash(), &[root])
     }
 
+    #[inline]
     pub fn new_with_nodes(root: H::Digest, nodes: &[Node<H>]) -> Self
     where
         H::Digest: Default,
@@ -69,6 +74,7 @@ where
         }
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.root
             == H::merge(
@@ -77,6 +83,7 @@ where
             )
     }
 
+    #[inline]
     pub fn get<K>(&self, key: K) -> Option<H::Digest>
     where
         K: ToBits<DEPTH>,
@@ -135,6 +142,7 @@ where
         Ok(new_hash)
     }
 
+    #[inline]
     pub fn insert<K>(&mut self, key: K, value: H::Digest) -> Result<(), SmtError>
     where
         K: ToBits<DEPTH>,
@@ -145,6 +153,7 @@ where
         Ok(())
     }
 
+    #[inline]
     pub fn update<K>(&mut self, key: K, value: H::Digest) -> Result<(), SmtError>
     where
         K: ToBits<DEPTH>,
@@ -183,6 +192,7 @@ where
     }
 
     /// Traverse the SMT and prune all stale nodes.
+    #[inline]
     pub fn traverse_and_prune(&mut self) -> Result<(), SmtError>
     where
         H::Digest: Eq + Hash,
@@ -217,6 +227,7 @@ where
         Ok(SmtMerkleProof { siblings })
     }
 
+    #[inline]
     pub fn get_inclusion_proof<K>(&self, key: K) -> Result<SmtMerkleProof<H, DEPTH>, SmtError>
     where
         K: ToBits<DEPTH>,
@@ -230,6 +241,7 @@ where
     /// inclusion proofs to verify the balance of a token in the tree and
     /// update it. If the token is not already in the tree, we still want an
     /// inclusion proof, so we use this function.
+    #[inline]
     pub fn get_inclusion_proof_zero<K>(
         &mut self,
         key: K,

--- a/crates/agglayer-tries/src/utils.rs
+++ b/crates/agglayer-tries/src/utils.rs
@@ -2,6 +2,7 @@ use agglayer_primitives::keccak::Hasher;
 
 /// Returns an array whose `i`th element is the root of an empty Merkle tree of
 /// depth `i`.
+#[inline]
 pub fn empty_hash_at_height<H, const DEPTH: usize>() -> [H::Digest; DEPTH]
 where
     H: Hasher,

--- a/crates/unified-bridge/src/bridge_exit.rs
+++ b/crates/unified-bridge/src/bridge_exit.rs
@@ -13,6 +13,7 @@ const EMPTY_METADATA_HASH: Digest = Digest(hex!(
 ));
 
 impl Hashable for TokenInfo {
+    #[inline]
     fn hash(&self) -> Digest {
         keccak256_combine([
             &self.origin_network.to_be_bytes(),
@@ -44,6 +45,7 @@ pub struct BridgeExit {
 
 impl BridgeExit {
     /// Creates a new [`BridgeExit`].
+    #[inline]
     pub fn new(
         leaf_type: LeafType,
         origin_network: NetworkId,
@@ -66,12 +68,14 @@ impl BridgeExit {
         }
     }
 
+    #[inline]
     pub fn is_transfer(&self) -> bool {
         self.leaf_type == LeafType::Transfer
     }
 }
 
 impl Hashable for BridgeExit {
+    #[inline]
     fn hash(&self) -> Digest {
         keccak256_combine([
             [self.leaf_type as u8].as_slice(),
@@ -86,12 +90,14 @@ impl Hashable for BridgeExit {
 }
 
 impl BridgeExit {
+    #[inline]
     pub fn is_message(&self) -> bool {
         self.leaf_type == LeafType::Message
     }
 
     /// Returns the [`TokenInfo`] considered for the the given amount.
     /// The amount corresponds to L1 ETH if the bridge exit is a message.
+    #[inline]
     pub fn amount_token_info(&self) -> TokenInfo {
         match self.leaf_type {
             LeafType::Message => L1_ETH,
@@ -107,6 +113,7 @@ impl BridgeExit {
 pub struct NetworkId(u32);
 
 impl Display for NetworkId {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -115,22 +122,26 @@ impl Display for NetworkId {
 impl NetworkId {
     pub const BITS: usize = u32::BITS as usize;
 
+    #[inline]
     pub const fn new(value: u32) -> Self {
         Self(value)
     }
 
+    #[inline]
     pub const fn to_u32(self) -> u32 {
         self.0
     }
 }
 
 impl From<u32> for NetworkId {
+    #[inline]
     fn from(value: u32) -> Self {
         Self(value)
     }
 }
 
 impl From<NetworkId> for u32 {
+    #[inline]
     fn from(value: NetworkId) -> Self {
         value.0
     }
@@ -139,6 +150,7 @@ impl From<NetworkId> for u32 {
 impl Deref for NetworkId {
     type Target = u32;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/crates/unified-bridge/src/global_index.rs
+++ b/crates/unified-bridge/src/global_index.rs
@@ -21,6 +21,7 @@ pub struct GlobalIndex {
 impl GlobalIndex {
     const MAINNET_FLAG_OFFSET: usize = 2 * 32;
 
+    #[inline]
     pub fn network_id(&self) -> NetworkId {
         let id = if self.mainnet_flag {
             0
@@ -31,6 +32,7 @@ impl GlobalIndex {
         NetworkId::new(id)
     }
 
+    #[inline]
     pub fn hash(&self) -> Digest {
         let global_index: U256 = (*self).into();
         keccak256(global_index.as_le_slice())
@@ -38,6 +40,7 @@ impl GlobalIndex {
 }
 
 impl From<U256> for GlobalIndex {
+    #[inline]
     fn from(value: U256) -> Self {
         let bytes = value.as_le_slice();
 
@@ -58,6 +61,7 @@ impl From<U256> for GlobalIndex {
 }
 
 impl From<GlobalIndex> for U256 {
+    #[inline]
     fn from(value: GlobalIndex) -> Self {
         let mut bytes = [0u8; 32];
 

--- a/crates/unified-bridge/src/imported_bridge_exit.rs
+++ b/crates/unified-bridge/src/imported_bridge_exit.rs
@@ -10,6 +10,7 @@ use crate::bridge_exit::BridgeExit;
 use crate::{global_index::GlobalIndex, local_exit_tree::proof::LETMerkleProof};
 
 impl Hashable for MerkleProof {
+    #[inline]
     fn hash(&self) -> Digest {
         keccak256_combine([
             self.root.as_slice(),
@@ -23,6 +24,7 @@ impl Hashable for MerkleProof {
     }
 }
 impl Hashable for Claim {
+    #[inline]
     fn hash(&self) -> Digest {
         match self {
             Claim::Mainnet(claim_from_mainnet) => claim_from_mainnet.hash(),
@@ -32,6 +34,7 @@ impl Hashable for Claim {
 }
 
 impl Hashable for ClaimFromMainnet {
+    #[inline]
     fn hash(&self) -> Digest {
         keccak256_combine([
             self.proof_leaf_mer.hash(),
@@ -42,6 +45,7 @@ impl Hashable for ClaimFromMainnet {
 }
 
 impl Hashable for ClaimFromRollup {
+    #[inline]
     fn hash(&self) -> Digest {
         keccak256_combine([
             self.proof_leaf_ler.hash(),
@@ -60,6 +64,7 @@ pub struct L1InfoTreeLeafInner {
 }
 
 impl L1InfoTreeLeafInner {
+    #[inline]
     pub fn hash(&self) -> Digest {
         keccak256_combine([
             self.global_exit_root.as_slice(),
@@ -79,6 +84,7 @@ pub struct L1InfoTreeLeaf {
 }
 
 impl L1InfoTreeLeaf {
+    #[inline]
     pub fn hash(&self) -> Digest {
         self.inner.hash()
     }
@@ -90,27 +96,34 @@ pub enum Error {
     /// same network type: mainnet or rollup.
     #[error("Mismatch between the global index and the inclusion proof.")]
     MismatchGlobalIndexInclusionProof,
+
     /// The provided L1 info root does not match the one provided in the
     /// inclusion proof.
     #[error("Mismatch between the provided L1 root and the inclusion proof.")]
     MismatchL1Root,
+
     /// The provided L1 info leaf does not refer to the same MER as the
     /// inclusion proof.
     #[error("Mismatch on the MER between the L1 leaf and the inclusion proof.")]
     MismatchMER,
+
     /// The provided L1 info leaf does not refer to the same RER as the
     /// inclusion proof.
     #[error("Mismatch on the RER between the L1 leaf and the inclusion proof.")]
     MismatchRER,
+
     /// The inclusion proof from the leaf to the LER is invalid.
     #[error("Invalid merkle path from the leaf to the LER.")]
     InvalidMerklePathLeafToLER,
+
     /// The inclusion proof from the LER to the RER is invalid.
     #[error("Invalid merkle path from the LER to the RER.")]
     InvalidMerklePathLERToRER,
+
     /// The inclusion proof from the GER to the L1 info Root is invalid.
     #[error("Invalid merkle path from the GER to the L1 Info Root.")]
     InvalidMerklePathGERToL1Root,
+
     /// The provided imported bridge exit does not target the right destination
     /// network.
     #[error("Invalid imported bridge exit destination network.")]
@@ -125,6 +138,7 @@ pub struct MerkleProof {
 }
 
 impl MerkleProof {
+    #[inline]
     pub fn new(root: Digest, siblings: [<Keccak256Hasher as Hasher>::Digest; 32]) -> Self {
         Self {
             proof: LETMerkleProof { siblings },
@@ -132,10 +146,12 @@ impl MerkleProof {
         }
     }
 
+    #[inline]
     pub fn verify(&self, leaf: Digest, leaf_index: u32) -> bool {
         self.proof.verify(leaf, leaf_index, self.root)
     }
 
+    #[inline]
     pub fn siblings(&self) -> &[<Keccak256Hasher as Hasher>::Digest; 32] {
         &self.proof.siblings
     }
@@ -153,13 +169,16 @@ pub enum Claim {
 pub struct ClaimFromMainnet {
     /// Proof from bridge exit leaf to MER
     pub proof_leaf_mer: MerkleProof,
+
     /// Proof from GER to L1Root
     pub proof_ger_l1root: MerkleProof,
+
     /// L1InfoTree leaf
     pub l1_leaf: L1InfoTreeLeaf,
 }
 
 impl ClaimFromMainnet {
+    #[inline]
     pub fn verify(
         &self,
         leaf: Digest,
@@ -207,6 +226,7 @@ pub struct ClaimFromRollup {
 }
 
 impl ClaimFromRollup {
+    #[inline]
     pub fn verify(
         &self,
         leaf: Digest,
@@ -258,8 +278,10 @@ pub struct ImportedBridgeExit {
     /// current network, and that the bridge exit is included in an imported
     /// LER
     pub bridge_exit: BridgeExit,
+
     /// The claim data
     pub claim_data: Claim,
+
     /// The global index of the imported bridge exit.
     pub global_index: GlobalIndex,
 }
@@ -267,6 +289,7 @@ pub struct ImportedBridgeExit {
 impl ImportedBridgeExit {
     /// Verifies that the provided inclusion path is valid and consistent with
     /// the provided LER
+    #[inline]
     pub fn verify_path(&self, l1root: Digest) -> Result<(), Error> {
         // Check that the inclusion proof and the global index both refer to mainnet or
         // rollup
@@ -288,6 +311,7 @@ impl ImportedBridgeExit {
 #[cfg(not(feature = "zkvm"))]
 impl ImportedBridgeExit {
     /// Creates a new [`ImportedBridgeExit`].
+    #[inline]
     pub fn new(bridge_exit: BridgeExit, claim_data: Claim, global_index: GlobalIndex) -> Self {
         Self {
             bridge_exit,
@@ -296,6 +320,7 @@ impl ImportedBridgeExit {
         }
     }
     /// Returns the considered L1 Info Root against which the claim is done.
+    #[inline]
     pub fn l1_info_root(&self) -> Digest {
         match &self.claim_data {
             Claim::Mainnet(claim) => claim.proof_ger_l1root.root,
@@ -305,6 +330,7 @@ impl ImportedBridgeExit {
 
     /// Returns the considered L1 Info Tree leaf index against which the claim
     /// is done.
+    #[inline]
     pub fn l1_leaf_index(&self) -> u32 {
         match &self.claim_data {
             Claim::Mainnet(claim) => claim.l1_leaf.l1_info_tree_index,
@@ -313,6 +339,7 @@ impl ImportedBridgeExit {
     }
 
     /// Hash the entire data structure.
+    #[inline]
     pub fn hash(&self) -> Digest {
         keccak256_combine([
             self.bridge_exit.hash(),
@@ -322,6 +349,7 @@ impl ImportedBridgeExit {
     }
 }
 
+#[inline]
 pub fn commit_imported_bridge_exits(iter: impl Iterator<Item = GlobalIndex>) -> Digest {
     keccak256_combine(iter.map(|global_index| global_index.hash()))
 }

--- a/crates/unified-bridge/src/local_exit_tree/mod.rs
+++ b/crates/unified-bridge/src/local_exit_tree/mod.rs
@@ -30,8 +30,10 @@ where
 pub enum LocalExitTreeError {
     #[error("Leaf index overflow")]
     LeafIndexOverflow,
+
     #[error("Index out of bounds")]
     IndexOutOfBounds,
+
     #[error("Frontier index out of bounds")]
     FrontierIndexOutOfBounds,
 }
@@ -41,6 +43,7 @@ where
     H: Hasher,
     H::Digest: Copy + Default + Serialize + for<'a> Deserialize<'a>,
 {
+    #[inline]
     fn default() -> Self {
         Self {
             leaf_count: 0,
@@ -57,19 +60,23 @@ where
     const MAX_NUM_LEAVES: u32 = ((1u64 << TREE_DEPTH) - 1) as u32;
 
     /// Creates a new empty [`LocalExitTree`].
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
 
+    #[inline]
     pub fn leaf_count(&self) -> u32 {
         self.leaf_count
     }
 
+    #[inline]
     pub fn frontier(&self) -> [H::Digest; TREE_DEPTH] {
         self.frontier
     }
 
     /// Creates a new [`LocalExitTree`] and populates its leaves.
+    #[inline]
     pub fn from_leaves(
         leaves: impl Iterator<Item = H::Digest>,
     ) -> Result<Self, LocalExitTreeError> {
@@ -84,6 +91,7 @@ where
 
     /// Creates a new [`LocalExitTree`] from its parts: leaf count, and
     /// frontier.
+    #[inline]
     pub fn from_parts(leaf_count: u32, frontier: [H::Digest; TREE_DEPTH]) -> Self {
         Self {
             leaf_count,
@@ -91,6 +99,7 @@ where
         }
     }
     /// Appends a leaf to the tree.
+    #[inline]
     pub fn add_leaf(&mut self, leaf: H::Digest) -> Result<u32, LocalExitTreeError> {
         if self.leaf_count >= Self::MAX_NUM_LEAVES {
             return Err(LocalExitTreeError::LeafIndexOverflow);
@@ -123,6 +132,7 @@ where
     }
 
     /// Computes and returns the root of the tree.
+    #[inline]
     pub fn get_root(&self) -> H::Digest {
         // `root` is the hash of the node we’re going to fill next.
         // Here, we compute the root, starting from the next (yet unfilled) leaf hash.
@@ -144,6 +154,7 @@ where
 }
 
 /// Returns the bit value at index `bit_idx` in `target`
+#[inline]
 fn get_bit_at(target: u32, bit_idx: usize) -> u32 {
     (target >> bit_idx) & 1
 }

--- a/crates/unified-bridge/src/local_exit_tree/proof.rs
+++ b/crates/unified-bridge/src/local_exit_tree/proof.rs
@@ -22,6 +22,7 @@ where
     H: Hasher,
     H::Digest: Serialize + DeserializeOwned + arbitrary::Arbitrary<'a>,
 {
+    #[inline]
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let siblings = <[H::Digest; TREE_DEPTH]>::arbitrary(u)?;
         Ok(Self { siblings })
@@ -33,6 +34,7 @@ where
     H: Hasher,
     H::Digest: Eq + Copy + Default + Serialize + DeserializeOwned,
 {
+    #[inline]
     pub fn verify(&self, leaf: H::Digest, leaf_index: u32, root: H::Digest) -> bool {
         let mut entry = leaf;
         let mut index = leaf_index;

--- a/crates/unified-bridge/src/token_info.rs
+++ b/crates/unified-bridge/src/token_info.rs
@@ -17,6 +17,7 @@ pub const L1_ETH: TokenInfo = TokenInfo {
 pub struct TokenInfo {
     /// Network which the token originates from
     pub origin_network: NetworkId,
+
     /// The address of the token on the origin network
     pub origin_token_address: Address,
 }
@@ -35,6 +36,7 @@ pub struct LeafTypeFromU8Error;
 impl TryFrom<u8> for LeafType {
     type Error = LeafTypeFromU8Error;
 
+    #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(Self::Transfer),
@@ -45,6 +47,7 @@ impl TryFrom<u8> for LeafType {
 }
 
 impl ToBits<192> for TokenInfo {
+    #[inline]
     fn to_bits(&self) -> [bool; 192] {
         let address_bytes = self.origin_token_address.0;
         // Security: We assume here that `address_bytes` is a fixed-size array of

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euixo pipefail
+
+time="$1"
+fuzzers=(
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_address"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_aggchain_data"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_bridge_exit"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_claim_from_mainnet"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_claim_from_rollup"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_digest"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_global_index"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_imported_bridge_exit"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_l1_info_tree_leaf_with_context"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_l1_info_tree_leaf_inner"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_merkle_proof"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_token_info"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_u256"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_parser_address"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_aggchain_data"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_bridge_exit"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_claim_from_mainnet"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_claim_from_rollup"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_digest"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_global_index"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_imported_bridge_exit"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_l1_info_tree_leaf_with_context"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_l1_info_tree_leaf_inner"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_merkle_proof"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_token_info"
+    "agglayer-interop-grpc-types/compat::v1::tests::fuzz_round_trip_u256"
+)
+
+printf '%s\0' "${fuzzers[@]}" | parallel --null --bar --joblog fuzz.log bash -c '
+    crate="$(echo {} | cut -d/ -f1)"
+    target="$(echo {} | cut -d/ -f2)"
+    cargo bolero test --rustc-bootstrap -p "$crate" --all-features "$target" -T '"$time"'
+'

--- a/scripts/make/Makefile.fuzz.toml
+++ b/scripts/make/Makefile.fuzz.toml
@@ -3,8 +3,7 @@ FUZZ_TIME = "60s"
 
 [tasks.install-bolero]
 description = "Install cargo-bolero"
-command = "cargo"
-args = ["install", "cargo-bolero"]
+install_crate = { crate_name = "cargo-bolero", version = "0.13.1" }
 
 [tasks.install-newer-clang]
 description = "Install newer clang on macos"

--- a/scripts/make/Makefile.fuzz.toml
+++ b/scripts/make/Makefile.fuzz.toml
@@ -1,0 +1,16 @@
+[env]
+FUZZ_TIME = "60s"
+
+[tasks.install-bolero]
+description = "Install cargo-bolero"
+command = "cargo"
+args = ["install", "cargo-bolero"]
+
+[tasks.install-newer-clang]
+description = "Install newer clang on macos"
+
+[tasks.fuzz-all]
+description = "Run all fuzzers for ${FUZZ_TIME} each"
+dependencies = ["install-bolero"]
+command = "./scripts/fuzz.sh"
+args = ["${FUZZ_TIME}"]


### PR DESCRIPTION
Reintroduce fuzzing infra lost in the switch from agglayer. Also, sprinkle `#[inline]` everywhere to make everything (and in particular the proofs) faster

The inlining gets us a 3-5% reduction in the total number of instructions for PP 🎉  It also reduces PP ELF size from 460008 bytes to 453808 bytes thanks to the new optimization opportunities

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
