### PR TITLE
chore: cleanup cargo.toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ dependencies = [
 name = "agglayer-primitives"
 version = "0.1.0"
 dependencies = [
+ "agglayer-primitives",
  "alloy-primitives",
  "arbitrary",
  "byteorder",
@@ -108,7 +109,7 @@ dependencies = [
  "k256",
  "rand 0.9.0",
  "serde",
- "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0)",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -121,7 +122,7 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.12",
- "tiny-keccak 2.0.2 (git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0)",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -234,7 +235,7 @@ dependencies = [
  "derive_more 1.0.0",
  "once_cell",
  "serde",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
 ]
 
 [[package]]
@@ -316,7 +317,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "sha3",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -443,7 +444,7 @@ dependencies = [
  "quote",
  "syn 2.0.99",
  "syn-solidity",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1151,7 +1152,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "tinyvec",
 ]
 
@@ -1271,7 +1272,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.99",
  "tempfile",
- "toml",
+ "toml 0.8.20",
 ]
 
 [[package]]
@@ -1392,7 +1393,7 @@ dependencies = [
  "hmac",
  "k256",
  "serde",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -1408,7 +1409,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
@@ -1427,7 +1428,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -2099,7 +2100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2118,7 +2119,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "sha3",
  "thiserror 1.0.69",
  "uuid",
@@ -2153,7 +2154,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "scale-info",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2239,7 +2240,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.99",
- "toml",
+ "toml 0.8.20",
  "walkdir",
 ]
 
@@ -2285,7 +2286,7 @@ dependencies = [
  "syn 2.0.99",
  "tempfile",
  "thiserror 1.0.69",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
  "unicode-xid",
 ]
 
@@ -2383,7 +2384,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -2413,7 +2414,7 @@ dependencies = [
  "solang-parser",
  "svm-rs",
  "thiserror 1.0.69",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
  "tokio",
  "tracing",
  "walkdir",
@@ -3378,15 +3379,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.41.0"
-source = "git+https://github.com/freyskeyd/insta?branch=chore%2Fupdating-deps-to-avoid-serialize-error#69c07695a1fb68beafc9b7bd949ab4f9d353b17f"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2d11b2f17a45095b8c3603928ba29d7d918d7129d0d0641a36ba73cf07daa6"
 dependencies = [
  "console",
- "lazy_static",
- "linked-hash-map",
+ "once_cell",
  "serde",
  "similar",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3518,7 +3519,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "signature",
 ]
 
@@ -3557,7 +3558,7 @@ dependencies = [
  "regex-syntax 0.8.5",
  "string_cache",
  "term",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
@@ -3593,7 +3594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3611,12 +3612,6 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4019,7 +4014,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
 ]
 
 [[package]]
@@ -4408,7 +4403,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac",
  "password-hash",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
 ]
 
 [[package]]
@@ -4809,7 +4804,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5205,7 +5200,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb09b49230ba22e8c676e7b75dfe2887dea8121f18b530ae0ba519ce442d2b21"
 dependencies = [
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
 ]
 
 [[package]]
@@ -5323,7 +5318,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5512,7 +5507,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
 ]
 
 [[package]]
@@ -5748,16 +5743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes.git?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha3"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5939,7 +5924,7 @@ dependencies = [
  "strum_macros",
  "subenum",
  "thiserror 1.0.69",
- "tiny-keccak 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
  "tracing",
  "typenum",
  "vec_map",
@@ -6065,7 +6050,7 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "serde",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
 ]
 
 [[package]]
@@ -6098,7 +6083,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "sp1-core-executor",
  "sp1-core-machine",
  "sp1-primitives",
@@ -6241,7 +6226,7 @@ dependencies = [
  "p3-symmetric",
  "serde",
  "serde_json",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "sp1-core-machine",
  "sp1-recursion-compiler",
  "sp1-stark",
@@ -6436,7 +6421,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "thiserror 1.0.69",
  "url",
  "zip",
@@ -6555,7 +6540,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6665,15 +6650,6 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "crunchy",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-4.0.0#d2ffd330259c8f290b07d99cc1ef1f74774382c2"
-dependencies = [
- "cfg-if",
  "crunchy",
 ]
 
@@ -6788,6 +6764,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7144,8 +7129,9 @@ dependencies = [
  "rs_merkle",
  "serde",
  "serde_with",
- "sha2 0.10.8 (git+https://github.com/sp1-patches/RustCrypto-hashes.git?tag=patch-sha2-0.10.8-sp1-4.0.0)",
+ "sha2",
  "thiserror 2.0.12",
+ "unified-bridge",
 ]
 
 [[package]]
@@ -7410,7 +7396,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7875,7 +7861,7 @@ dependencies = [
  "pasta_curves 0.5.1",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2",
  "sha3",
  "subtle",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,19 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [workspace.dependencies]
-# Project dependencies
-agglayer-primitives = { path = "crates/agglayer-primitives" }
+agglayer-blockchain = { path = "crates/agglayer-blockchain" }
 agglayer-interop-types = { path = "crates/agglayer-interop-types" }
 agglayer-interop-grpc-types = { path = "crates/agglayer-interop-grpc-types" }
+agglayer-primitives = { path = "crates/agglayer-primitives" }
 agglayer-tries = { path = "crates/agglayer-tries" }
 unified-bridge = { path = "crates/unified-bridge" }
 
-# Core dependencies
+sp1-core-machine = "=4.1.4"
+sp1-sdk = "=4.1.4"
+sp1-primitives = "=4.1.4"
+sp1-prover = "=4.1.4"
+sp1-zkvm = { version = "=4.1.4", default-features = false }
+
 alloy = { version = "0.8.1", features = ["full"] }
 alloy-primitives = { version = "0.8.25", features = ["serde", "k256"] }
 anyhow = "1.0.98"
@@ -33,6 +38,7 @@ base64 = "0.22.0"
 bincode = "1.3.3"
 bolero = { version = "0.13.0", features = ["arbitrary"] }
 buildstructor = "0.5.4"
+byteorder = "1.5.0"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 dirs = "5.0.1"
 dotenvy = "0.15.7"
@@ -40,19 +46,31 @@ educe = "0.6.0"
 ethers = "2.0.14"
 ethers-gcp-kms-signer = "0.1.5"
 ethers-signers = "2.0.14"
+fail = { version = "0.5.1", default-features = false }
 futures = "0.3.31"
 hex = "0.4.3"
+hex-literal = "0.4"
 http = "1.3.1"
 hyper = "1.6.0"
+insta = { version = "1.43.0", features = ["toml", "yaml", "json"] }
 jsonrpsee = { version = "0.24.7", features = ["full"] }
+k256 = "0.13.4"
 lazy_static = "1.5.0"
+mockall = "0.13.1"
 parking_lot = "0.12.3"
+pbjson = "0.7.0"
 pin-project = "1.1.9"
 prost = "0.13.4"
+rand = "0.9.0"
+rs_merkle = { version = "1.4", default-features = false }
+rstest = "0.22.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.138"
 serde_with = "3.12.0"
+sha2 = "0.10.8"
+test-log = "0.2.16"
 thiserror = "2.0.11"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 tokio-util = "0.7.14"
@@ -64,22 +82,3 @@ tracing = "0.1.41"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2.5.4", features = ["serde"] }
-
-# Test dependencies
-fail = { version = "0.5.1", default-features = false }
-insta = { git = "https://github.com/freyskeyd/insta", branch = "chore/updating-deps-to-avoid-serialize-error", features = [
-    "toml",
-    "yaml",
-    "json",
-] }
-mockall = "0.13.1"
-rand = "0.9.0"
-rstest = "0.22.0"
-test-log = "0.2.16"
-
-# SP1 dependencies
-sp1-core-machine = "=4.1.4"
-sp1-sdk = "=4.1.4"
-sp1-primitives = "=4.1.4"
-sp1-prover = "=4.1.4"
-sp1-zkvm = { version = "=4.1.4", default-features = false }

--- a/crates/agglayer-interop-grpc-types/Cargo.toml
+++ b/crates/agglayer-interop-grpc-types/Cargo.toml
@@ -16,7 +16,7 @@ agglayer-interop-types = { workspace = true, optional = true }
 
 bincode = { workspace = true, optional = true }
 hex.workspace = true
-pbjson = "0.7.0"
+pbjson.workspace = true
 prost.workspace = true
 serde.workspace = true
 tonic-types.workspace = true

--- a/crates/agglayer-interop-types/Cargo.toml
+++ b/crates/agglayer-interop-types/Cargo.toml
@@ -13,18 +13,19 @@ agglayer-primitives.workspace = true
 agglayer-tries.workspace = true
 unified-bridge.workspace = true
 
+sp1-sdk.workspace = true
+sp1-core-machine.workspace = true
+sp1-prover.workspace = true
+
 arbitrary = { workspace = true, optional = true }
+bincode.workspace = true
 educe.workspace = true
 ethers = { workspace = true, optional = true }
 hex.workspace = true
 serde.workspace = true
 serde_with.workspace = true
-sp1-sdk.workspace = true
-sp1-core-machine.workspace = true
-sp1-prover.workspace = true
 thiserror.workspace = true
-bincode.workspace = true
 rand.workspace = true
 
 [dev-dependencies]
-agglayer-interop-types = { path = ".", features = ["testutils"] }
+agglayer-interop-types = { workspace = true, features = ["testutils"] }

--- a/crates/agglayer-interop/Cargo.toml
+++ b/crates/agglayer-interop/Cargo.toml
@@ -4,10 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[dependencies]
-agglayer-interop-types = { workspace = true }
-agglayer-interop-grpc-types = { workspace = true, optional = true }
-
 [features]
 default = []
 
@@ -18,3 +14,7 @@ testutils = ["agglayer-interop-types/testutils"]
 
 [lints]
 workspace = true
+
+[dependencies]
+agglayer-interop-types.workspace = true
+agglayer-interop-grpc-types = { workspace = true, optional = true }

--- a/crates/agglayer-primitives/Cargo.toml
+++ b/crates/agglayer-primitives/Cargo.toml
@@ -9,20 +9,18 @@ default = ["keccak"]
 keccak = ["dep:tiny-keccak"]
 testutils = ["alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand"]
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy-primitives.workspace = true
 arbitrary = { workspace = true, optional = true }
-byteorder = "1.5.0"
-k256 = "0.13.4"
-serde = { version = "1.0.219", features = ["derive"] }
-hex = "0.4.3"
-rand = { version = "0.9.0", optional = true }
-tiny-keccak = { optional = true, git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0", features = [
-    "keccak",
-] }
+byteorder.workspace = true
+k256.workspace = true
+serde.workspace = true
+hex.workspace = true
+rand = { workspace = true, optional = true }
+tiny-keccak = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = "0.9.0"
-
-[lints]
-workspace = true
+agglayer-primitives = { workspace = true, features = ["testutils"] }

--- a/crates/agglayer-tries/Cargo.toml
+++ b/crates/agglayer-tries/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 agglayer-primitives.workspace = true
 
@@ -13,11 +16,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 agglayer-primitives = { workspace = true, features = ["testutils"] }
-rand = "0.9.0"
-rs_merkle = { version = "1.4", default-features = false }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0", features = [
-    "keccak",
-] }
-
-[lints]
-workspace = true
+rand.workspace = true
+rs_merkle.workspace = true
+tiny-keccak.workspace = true

--- a/crates/unified-bridge/Cargo.toml
+++ b/crates/unified-bridge/Cargo.toml
@@ -8,22 +8,22 @@ license.workspace = true
 zkvm = []
 testutils = ["dep:arbitrary", "agglayer-primitives/testutils"]
 
+[lints]
+workspace = true
+
 [dependencies]
 agglayer-primitives.workspace = true
 agglayer-tries.workspace = true
 
 arbitrary = { workspace = true, optional = true }
-hex-literal = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_with = { version = "3" }
-sha2 = { git = "https://github.com/sp1-patches/RustCrypto-hashes.git", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
+hex-literal.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-agglayer-primitives = { workspace = true, features = ["testutils"] }
+unified-bridge = { workspace = true, features = ["testutils"] }
 hex.workspace = true
-rand = "0.9.0"
-rs_merkle = { version = "1.4", default-features = false }
-
-[lints]
-workspace = true
+rand.workspace = true
+rs_merkle.workspace = true


### PR DESCRIPTION
Unify all dependencies.

After this is released, we'll need to use [the patch section of *-proof binary crates](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section) in order to set the SP1 crates. Among other reasons, the Cargo.lock file was showing that not all our uses of eg. sha2 were patched with the SP1 patches, through the bs58 -> sha2 code path for example.

This also reduces a bit the crate duplication in our graph, removing 5 lines in the output of `cargo tree`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
