### PR TITLE
fix: make signature field in AggchainData optional

### DIFF
--- a/crates/agglayer-interop-types/src/aggchain_proof.rs
+++ b/crates/agglayer-interop-types/src/aggchain_proof.rs
@@ -21,7 +21,7 @@ pub enum AggchainData {
         /// Chain-specific commitment forwarded through the PP.
         aggchain_params: Digest,
         /// Signature of the aggchain proof.
-        signature: Box<Signature>,
+        signature: Option<Box<Signature>>,
     },
 }
 


### PR DESCRIPTION
# Description

Relax the signature on `aggchain-proof` to have it as option

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
