### PR TITLE
docs: precise lsb indexing for the mainnet flag

### DIFF
--- a/crates/unified-bridge/src/aggchain_proof.rs
+++ b/crates/unified-bridge/src/aggchain_proof.rs
@@ -5,7 +5,7 @@ use sha2::{Digest as Sha256Digest, Sha256};
 use crate::NetworkId;
 
 /// Public values to verify the SP1 aggchain proof.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AggchainProofPublicValues {
     /// Previous local exit root.
     pub prev_local_exit_root: Digest,

--- a/crates/unified-bridge/src/global_index.rs
+++ b/crates/unified-bridge/src/global_index.rs
@@ -36,7 +36,8 @@ impl arbitrary::Arbitrary<'_> for GlobalIndex {
 }
 
 impl GlobalIndex {
-    const MAINNET_FLAG_OFFSET: usize = 2 * 32;
+    /// Mainnet flag masked with LSB indexing.
+    const MAINNET_FLAG_LSB_OFFSET: usize = 2 * 32;
 
     #[inline]
     pub fn new(network: NetworkId, leaf_index: u32) -> Self {
@@ -98,7 +99,7 @@ impl TryFrom<U256> for GlobalIndex {
     fn try_from(value: U256) -> Result<Self, Self::Error> {
         let bytes = value.as_le_slice();
 
-        let mainnet_flag = value.bit(Self::MAINNET_FLAG_OFFSET);
+        let mainnet_flag = value.bit(Self::MAINNET_FLAG_LSB_OFFSET);
         // Security: This uses the slice to fixed array TryFrom impl in the std
         // library that is technically fallible. However, our range length in
         // both cases is equal to u32::len() so it is safe to disregard the Result


### PR DESCRIPTION
# Description

Explicit lsb indexing for the mainnet flag in global index.

Also quickly add `Debug` for `AggchainProofPublicValues` to avoid unrolling it manually on `provers` logs

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
