### PR TITLE
feat: expose the aggchain proof public values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6427,9 +6427,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rstest = "0.25.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.12"
-sha2 = "0.10.9"
+sha2 = "0.10.8"
 test-log = "0.2.16"
 thiserror = "2.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/error.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/error.rs
@@ -120,6 +120,16 @@ impl Error {
     }
 
     #[inline]
+    pub fn deserializing_aggchain_proof_public_values(e: bincode::Error) -> Self {
+        Error {
+            kind: ErrorKind::InvalidData,
+            message: "failed to deserialize aggchain proof public values".to_string(),
+            field: vec![],
+            source: Some(SourceError::Bincode(e)),
+        }
+    }
+
+    #[inline]
     pub fn parsing_signature(e: SignatureError) -> Self {
         Error {
             kind: ErrorKind::InvalidData,

--- a/crates/agglayer-interop-types/src/aggchain_proof.rs
+++ b/crates/agglayer-interop-types/src/aggchain_proof.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use sp1_core_machine::reduce::SP1ReduceProof;
 use sp1_prover::InnerSC;
 use sp1_sdk::SP1VerifyingKey;
+pub use unified_bridge::AggchainProofPublicValues;
 
 use crate::Digest;
 
@@ -22,6 +23,8 @@ pub enum AggchainData {
         aggchain_params: Digest,
         /// Signature of the aggchain proof.
         signature: Option<Box<Signature>>,
+        /// Optional aggchain proof public values.
+        public_values: Option<Box<AggchainProofPublicValues>>,
     },
 }
 

--- a/crates/unified-bridge/src/aggchain_proof.rs
+++ b/crates/unified-bridge/src/aggchain_proof.rs
@@ -5,7 +5,8 @@ use sha2::{Digest as Sha256Digest, Sha256};
 use crate::NetworkId;
 
 /// Public values to verify the SP1 aggchain proof.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary))]
 pub struct AggchainProofPublicValues {
     /// Previous local exit root.
     pub prev_local_exit_root: Digest,


### PR DESCRIPTION
# Description

Expose the `"public_values"` entry from the context, corresponding to the aggchain proof public values.

Relates to https://github.com/agglayer/agglayer/issues/821

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
