### PR TITLE
refactor: wrap `alloy_primitives::Address` and give data types specific `serde` names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "byteorder",
+ "derive_more 2.0.1",
  "hex",
  "k256",
  "rand 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ bolero = { version = "0.13.0", features = ["arbitrary"] }
 buildstructor = "0.5.4"
 byteorder = "1.5"
 clap = { version = "4.5", features = ["derive", "env"] }
+derive_more = { version = "2.0", features = ["from", "into", "from_str", "as_ref", "display"] }
 dirs = "5.0"
 dotenvy = "0.15.7"
 educe = "0.6.0"

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/address.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/address.rs
@@ -17,7 +17,7 @@ impl From<Address> for v1::FixedBytes20 {
     #[inline]
     fn from(value: Address) -> Self {
         v1::FixedBytes20 {
-            value: Bytes::copy_from_slice(&value.0 .0),
+            value: Bytes::copy_from_slice(value.as_slice()),
         }
     }
 }

--- a/crates/agglayer-primitives/Cargo.toml
+++ b/crates/agglayer-primitives/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 alloy-primitives.workspace = true
 arbitrary = { workspace = true, optional = true }
 byteorder.workspace = true
+derive_more.workspace = true
 k256.workspace = true
 serde.workspace = true
 hex.workspace = true

--- a/crates/agglayer-primitives/src/address.rs
+++ b/crates/agglayer-primitives/src/address.rs
@@ -17,6 +17,7 @@ pub use alloy_primitives::Address as AlloyAddress;
     derive_more::Into,
     derive_more::FromStr,
     derive_more::AsRef,
+    derive_more::AsMut,
     derive_more::Display,
     derive_more::LowerHex,
     derive_more::UpperHex,
@@ -60,11 +61,6 @@ impl Address {
     #[inline]
     pub const fn as_slice(&self) -> &[u8] {
         self.as_alloy().0.as_slice()
-    }
-
-    #[inline]
-    pub fn copy_from_slice(&mut self, slice: &[u8]) {
-        self.0.copy_from_slice(slice);
     }
 }
 

--- a/crates/agglayer-primitives/src/address.rs
+++ b/crates/agglayer-primitives/src/address.rs
@@ -6,7 +6,6 @@ pub use alloy_primitives::Address as AlloyAddress;
     Debug,
     Clone,
     Copy,
-    Default,
     PartialEq,
     Eq,
     PartialOrd,

--- a/crates/agglayer-primitives/src/address.rs
+++ b/crates/agglayer-primitives/src/address.rs
@@ -26,6 +26,7 @@ pub use alloy_primitives::Address as AlloyAddress;
 #[into(AlloyAddress, [u8; 20])]
 #[as_ref(AlloyAddress, [u8; 20], [u8])]
 #[repr(transparent)]
+#[serde(rename = "agglayer_primitives::Address")]
 pub struct Address(AlloyAddress);
 
 impl Address {

--- a/crates/agglayer-primitives/src/address.rs
+++ b/crates/agglayer-primitives/src/address.rs
@@ -1,0 +1,84 @@
+pub use alloy_primitives::Address as AlloyAddress;
+
+/// A wrapper over [alloy_primitives::Address] that allows us to add custom
+/// methods and trait implementations.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::FromStr,
+    derive_more::AsRef,
+    derive_more::Display,
+    derive_more::LowerHex,
+    derive_more::UpperHex,
+)]
+#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary))]
+#[from(AlloyAddress, [u8; 20])]
+#[into(AlloyAddress, [u8; 20])]
+#[as_ref(AlloyAddress, [u8; 20], [u8])]
+#[repr(transparent)]
+pub struct Address(AlloyAddress);
+
+impl Address {
+    pub const ZERO: Self = Self::from_alloy(AlloyAddress::ZERO);
+
+    #[inline]
+    pub const fn new(bytes: [u8; 20]) -> Self {
+        Self::from_alloy(AlloyAddress::new(bytes))
+    }
+
+    #[inline]
+    pub const fn from_alloy(address: AlloyAddress) -> Self {
+        Self(address)
+    }
+
+    #[inline]
+    pub const fn as_alloy(&self) -> &AlloyAddress {
+        &self.0
+    }
+
+    #[inline]
+    pub const fn into_alloy(self) -> AlloyAddress {
+        self.0
+    }
+
+    #[inline]
+    pub const fn into_array(self) -> [u8; 20] {
+        self.into_alloy().into_array()
+    }
+
+    #[inline]
+    pub const fn as_slice(&self) -> &[u8] {
+        self.as_alloy().0.as_slice()
+    }
+
+    #[inline]
+    pub fn copy_from_slice(&mut self, slice: &[u8]) {
+        self.0.copy_from_slice(slice);
+    }
+}
+
+impl TryFrom<&[u8]> for Address {
+    type Error = std::array::TryFromSliceError;
+
+    #[inline]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        AlloyAddress::try_from(value).map(Self)
+    }
+}
+
+#[macro_export]
+macro_rules! address {
+    ($($addr:literal)*) => {
+        $crate::Address::from_alloy($crate::alloy_primitives::address!($($addr)*))
+    };
+}

--- a/crates/agglayer-primitives/src/address.rs
+++ b/crates/agglayer-primitives/src/address.rs
@@ -78,3 +78,15 @@ macro_rules! address {
         $crate::Address::from_alloy($crate::alloy_primitives::address!($($addr)*))
     };
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn address_macro() {
+        let address = address!("00112233445566778899aabbccddeeff00112233");
+        let alloy_address = alloy_primitives::address!("00112233445566778899aabbccddeeff00112233");
+        assert_eq!(address, Address::from_alloy(alloy_address));
+    }
+}

--- a/crates/agglayer-primitives/src/digest.rs
+++ b/crates/agglayer-primitives/src/digest.rs
@@ -123,7 +123,7 @@ impl<'de> Deserialize<'de> for Digest {
             Ok(Digest(s))
         } else {
             #[derive(::serde::Deserialize)]
-            #[serde(rename = "NewDigest")]
+            #[serde(rename = "agglayer_primitives::Digest")]
             struct Value([u8; 32]);
 
             let value = Value::deserialize(deserializer)?;
@@ -141,7 +141,7 @@ impl Serialize for Digest {
         if serializer.is_human_readable() {
             format!("{self:#x}").serialize(serializer)
         } else {
-            serializer.serialize_newtype_struct("NewDigest", &self.0)
+            serializer.serialize_newtype_struct("agglayer_primitives::Digest", &self.0)
         }
     }
 }

--- a/crates/agglayer-primitives/src/lib.rs
+++ b/crates/agglayer-primitives/src/lib.rs
@@ -1,7 +1,8 @@
-pub use alloy_primitives::{address, ruint, Address, SignatureError, B256, U256, U512};
+pub use alloy_primitives::{self, ruint, SignatureError, B256, U256, U512};
 
 pub use crate::signature::Signature;
 
+mod address;
 pub mod bytes;
 mod digest;
 #[cfg(feature = "keccak")]
@@ -9,5 +10,6 @@ pub mod keccak;
 mod signature;
 mod utils;
 
+pub use address::Address;
 pub use digest::Digest;
 pub use utils::{FromBool, FromU256, Hashable};

--- a/crates/agglayer-primitives/src/signature.rs
+++ b/crates/agglayer-primitives/src/signature.rs
@@ -22,7 +22,7 @@ impl Signature {
 
     #[inline]
     pub fn recover_address_from_prehash(&self, prehash: &B256) -> Result<Address, SignatureError> {
-        self.0.recover_address_from_prehash(prehash).map(Into::into)
+        self.0.recover_address_from_prehash(prehash).map(Address::from)
     }
 
     #[inline]

--- a/crates/agglayer-primitives/src/signature.rs
+++ b/crates/agglayer-primitives/src/signature.rs
@@ -22,7 +22,9 @@ impl Signature {
 
     #[inline]
     pub fn recover_address_from_prehash(&self, prehash: &B256) -> Result<Address, SignatureError> {
-        self.0.recover_address_from_prehash(prehash).map(Address::from)
+        self.0
+            .recover_address_from_prehash(prehash)
+            .map(Address::from)
     }
 
     #[inline]

--- a/crates/agglayer-primitives/src/signature.rs
+++ b/crates/agglayer-primitives/src/signature.rs
@@ -22,7 +22,7 @@ impl Signature {
 
     #[inline]
     pub fn recover_address_from_prehash(&self, prehash: &B256) -> Result<Address, SignatureError> {
-        self.0.recover_address_from_prehash(prehash)
+        self.0.recover_address_from_prehash(prehash).map(Into::into)
     }
 
     #[inline]

--- a/crates/unified-bridge/src/imported_bridge_exit.rs
+++ b/crates/unified-bridge/src/imported_bridge_exit.rs
@@ -97,6 +97,7 @@ impl L1InfoTreeLeaf {
 }
 
 #[derive(Clone, Debug, Error, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename = "unified_bridge::Error")]
 pub enum Error {
     /// The global index and the inclusion proof do not both correspond to the
     /// same network type: mainnet or rollup.

--- a/crates/unified-bridge/src/local_exit_tree/mod.rs
+++ b/crates/unified-bridge/src/local_exit_tree/mod.rs
@@ -181,7 +181,7 @@ mod tests {
         deposit.amount = U256::try_from_be_slice(amount_bytes.as_slice()).unwrap();
 
         let dest_addr = hex::decode("c949254d682d8c9ad5682521675b8f43b102aec4").unwrap_or_default();
-        deposit.dest_address.copy_from_slice(&dest_addr);
+        deposit.dest_address.as_mut().copy_from_slice(&dest_addr);
 
         let leaf_hash = deposit.hash();
         assert_eq!(

--- a/crates/unified-bridge/src/local_exit_tree/mod.rs
+++ b/crates/unified-bridge/src/local_exit_tree/mod.rs
@@ -170,9 +170,9 @@ mod tests {
         let mut deposit = BridgeExit::new(
             LeafType::Transfer,
             0.into(),
-            Address::default(),
+            Address::ZERO,
             1.into(),
-            Address::default(),
+            Address::ZERO,
             U256::default(),
             vec![],
         );

--- a/crates/unified-bridge/src/token_info.rs
+++ b/crates/unified-bridge/src/token_info.rs
@@ -48,7 +48,7 @@ impl TryFrom<u8> for LeafType {
 impl ToBits<192> for TokenInfo {
     #[inline]
     fn to_bits(&self) -> [bool; 192] {
-        let address_bytes = self.origin_token_address.0;
+        let address_bytes = self.origin_token_address.as_slice();
         // Security: We assume here that `address_bytes` is a fixed-size array of
         // 20 bytes. The following code could panic otherwise.
         std::array::from_fn(|i| {


### PR DESCRIPTION
## Motivation

In order to avoid further storage compatibility regressions, `serde-reflection` can be employed to capture a snapshot of the encoding format as understood by serde. The package, however, has a number of limitations around handling generics and distinct types with identical names defined in different modules (a common occurrence with `Error`). This 

## Additions and Changes

* The `alloy_primitives::Address` is wrapped and exposed as `agglayer_primitives::Address` with a specific serde name.
* Some other types have been given specific serde names to avoid name clashes.

## Breaking changes

Hopefully none, serde names at type level do not factor into the serialization format of `json`, `toml`, or `bincode`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
