### PR TITLE
feat: use U256 instead of global index

### DIFF
--- a/crates/unified-bridge/src/global_index.rs
+++ b/crates/unified-bridge/src/global_index.rs
@@ -86,7 +86,7 @@ impl GlobalIndex {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
 pub enum InvalidGlobalIndexError {
     #[error(transparent)]
     InvalidRollupIndex(InvalidRollupIndexError),

--- a/crates/unified-bridge/src/rollup_index.rs
+++ b/crates/unified-bridge/src/rollup_index.rs
@@ -30,7 +30,7 @@ impl<'de> Deserialize<'de> for RollupIndex {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
 #[error("Invalid rollup index")]
 pub struct InvalidRollupIndexError;
 


### PR DESCRIPTION
# Description

Use U256 directly instead of GlobalIndex in order to preserve the values of the padded unused bits.

Companion of: 
- https://github.com/agglayer/agglayer/pull/857
- https://github.com/agglayer/provers/pull/244

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
