### PR TITLE
test: remove a dependency of dubious value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ dependencies = [
  "bincode",
  "serde",
  "sp1-sdk",
- "unified-bridge",
 ]
 
 [[package]]

--- a/crates/agglayer-bincode/Cargo.toml
+++ b/crates/agglayer-bincode/Cargo.toml
@@ -11,6 +11,4 @@ bincode.workspace = true
 serde.workspace = true
 
 [dev-dependencies]
-unified-bridge.workspace = true
-
 sp1-sdk.workspace = true

--- a/crates/agglayer-bincode/src/lib.rs
+++ b/crates/agglayer-bincode/src/lib.rs
@@ -102,11 +102,11 @@ impl<Opts: Options> Codec<Opts> {
 
 #[cfg(test)]
 mod test {
-    use unified_bridge::NetworkId;
-
     #[test]
     fn sp1_endians() {
-        let network_id = NetworkId::new(0x00112233);
+        type NetworkId = u32;
+
+        let network_id: NetworkId = 0x00112233;
         let network_id_enc = super::sp1v4().serialize(&network_id).unwrap();
 
         let mut stdin0 = sp1_sdk::SP1Stdin::new();


### PR DESCRIPTION
This removes the circular dep between packages (thought not crates). The `release-plz` tool does not seem to like it.