### PR TITLE
fix: ensure self-referential crates use path dependencies

### DIFF
--- a/crates/agglayer-evm-client/Cargo.toml
+++ b/crates/agglayer-evm-client/Cargo.toml
@@ -22,4 +22,4 @@ mockall = { workspace = true, optional = true }
 thiserror.workspace = true
 
 [dev-dependencies]
-agglayer-evm-client = { workspace = true, features = ["testutils"] }
+agglayer-evm-client = { path = ".", features = ["testutils"] }


### PR DESCRIPTION
This PR ensures that we can publish a self-referential crate to crates.io by making it use a path dependency when referring to itself, rather than a workspace dependency.