### PR TITLE
chore: rename commitment version to ib commitment version

### DIFF
--- a/crates/unified-bridge/src/imported_bridge_exit.rs
+++ b/crates/unified-bridge/src/imported_bridge_exit.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::{
     bridge_exit::BridgeExit, global_index::GlobalIndex, local_exit_tree::proof::LETMerkleProof,
-    CommitmentVersion, RollupIndex,
+    ImportedBridgeExitCommitmentVersion, RollupIndex,
 };
 
 impl Hashable for MerkleProof {
@@ -399,6 +399,7 @@ impl GlobalIndexWithLeafHash {
 }
 
 /// The values which compose the commitment on the imported bridge exits.
+#[derive(Debug, Clone)]
 pub struct ImportedBridgeExitCommitmentValues {
     pub claims: Vec<GlobalIndexWithLeafHash>,
 }
@@ -406,9 +407,9 @@ pub struct ImportedBridgeExitCommitmentValues {
 impl ImportedBridgeExitCommitmentValues {
     /// Returns the expected signed commitment for the provided version.
     #[inline]
-    pub fn commitment(&self, version: CommitmentVersion) -> Digest {
+    pub fn commitment(&self, version: ImportedBridgeExitCommitmentVersion) -> Digest {
         match version {
-            CommitmentVersion::V2 => {
+            ImportedBridgeExitCommitmentVersion::V2 => {
                 // Commits solely to the global index of each imported bridge exit. Designed
                 // prior to having any notion of aggchain proof.
                 keccak256_combine(
@@ -417,7 +418,7 @@ impl ImportedBridgeExitCommitmentValues {
                         .map(|ibe| keccak256(ibe.global_index.as_le_slice())),
                 )
             }
-            CommitmentVersion::V3 => {
+            ImportedBridgeExitCommitmentVersion::V3 => {
                 // Adds the bridge exit hashes in the commitment to ensure that the aggchain
                 // proof and PP talk about the exact same set of imported bridge exits.
                 keccak256_combine(self.claims.iter().map(|ibe| {

--- a/crates/unified-bridge/src/lib.rs
+++ b/crates/unified-bridge/src/lib.rs
@@ -22,7 +22,7 @@ pub use rollup_index::{InvalidRollupIndexError, RollupIndex};
 pub use token_info::{LeafType, TokenInfo, L1_ETH};
 
 #[derive(Debug, Clone, Copy)]
-pub enum CommitmentVersion {
+pub enum ImportedBridgeExitCommitmentVersion {
     V2,
     V3,
 }


### PR DESCRIPTION
Renaming `CommitmentVersion` -> `ImportedBridgeExitCommitmentVersion`

Needed for https://github.com/agglayer/agglayer/pull/963
