### PR TITLE
feat: move all dynamic error types to eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 name = "agglayer-elf-build"
 version = "0.9.0"
 dependencies = [
- "anyhow",
  "cargo_metadata",
  "clap",
+ "eyre",
  "rstest",
  "sp1-build",
 ]
@@ -53,6 +53,8 @@ name = "agglayer-elf-build-sample-program-host"
 version = "0.1.0"
 dependencies = [
  "agglayer-elf-build",
+ "color-eyre",
+ "eyre",
 ]
 
 [[package]]
@@ -69,8 +71,8 @@ dependencies = [
  "agglayer-evm-client",
  "agglayer-primitives",
  "alloy",
- "anyhow",
  "async-trait",
+ "eyre",
  "mockall",
  "thiserror 2.0.16",
 ]
@@ -88,9 +90,9 @@ name = "agglayer-interop-grpc-types"
 version = "0.9.0"
 dependencies = [
  "agglayer-interop-types",
- "anyhow",
  "bincode",
  "bolero",
+ "eyre",
  "insta",
  "pbjson",
  "prost",
@@ -1729,6 +1731,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,7 +3380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3822,6 +3851,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "p256"
@@ -6607,6 +6642,16 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ sp1-zkvm = { version = "=5.0.0", default-features = false }
 
 alloy = { version = "0.14.0", features = ["full"] }
 alloy-primitives = { version = "1.3", features = ["serde", "k256"] }
-anyhow = "1.0"
 arbitrary = { version = "1.4", features = ["derive"] }
 arc-swap = "1.7"
 async-trait = "0.1.89"
@@ -45,6 +44,7 @@ buildstructor = "0.5.4"
 byteorder = "1.5"
 cargo_metadata = "0.18"
 clap = { version = "4.5", features = ["derive", "env"] }
+color-eyre = "0.6.5"
 derive_more = { version = "2.0", features = [
     "from",
     "into",
@@ -55,6 +55,7 @@ derive_more = { version = "2.0", features = [
 dirs = "5.0"
 dotenvy = "0.15.7"
 educe = "0.6.0"
+eyre = "0.6.12"
 fail = { version = "0.5.1", default-features = false }
 futures = "0.3.31"
 hex = "0.4.3"

--- a/crates/agglayer-elf-build/Cargo.toml
+++ b/crates/agglayer-elf-build/Cargo.toml
@@ -6,9 +6,9 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 cargo_metadata.workspace = true
 clap.workspace = true
+eyre.workspace = true
 
 sp1-build.workspace = true
 

--- a/crates/agglayer-elf-build/sample-program/host/Cargo.toml
+++ b/crates/agglayer-elf-build/sample-program/host/Cargo.toml
@@ -8,4 +8,7 @@ publish = false
 agglayer-elf-build.workspace = true
 
 [build-dependencies]
+color-eyre.workspace = true
+eyre.workspace = true
+
 agglayer-elf-build.workspace = true

--- a/crates/agglayer-elf-build/sample-program/host/build.rs
+++ b/crates/agglayer-elf-build/sample-program/host/build.rs
@@ -1,3 +1,5 @@
-pub fn main() -> agglayer_elf_build::Result<()> {
-    agglayer_elf_build::build_program("crates/agglayer-elf-build/sample-program/zkvm").map(drop)
+pub fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+    agglayer_elf_build::build_program("crates/agglayer-elf-build/sample-program/zkvm")?;
+    Ok(())
 }

--- a/crates/agglayer-elf-build/src/lib.rs
+++ b/crates/agglayer-elf-build/src/lib.rs
@@ -1,5 +1,3 @@
-pub use anyhow::{Error, Result};
-
 pub mod zkvm_build;
 
 pub use zkvm_build::{build_program, ProgramBuilder};

--- a/crates/agglayer-elf-build/src/zkvm_build/mod.rs
+++ b/crates/agglayer-elf-build/src/zkvm_build/mod.rs
@@ -36,8 +36,10 @@
 //! crate. Note the path is relative to the workspace root:
 //!
 //! ```ignore
-//! fn main() {
-//!     agglayer_elf_build::build_program("crates/whatever-proof-program").unwrap();
+//! fn main() -> eyre::Result<()> {
+//!     color_eyre::install()?;
+//!     agglayer_elf_build::build_program("crates/whatever-proof-program")?;
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -83,7 +85,7 @@ pub const DEFAULT_DOCKER_TAG: &str =
 pub const CACHED_ELF_PATH: &str = "elf/riscv32im-succinct-zkvm-elf";
 
 /// Convenience function to build the zkvm ELF if no customization is needed.
-pub fn build_program(program_dir: impl AsRef<Utf8Path>) -> anyhow::Result<Utf8PathBuf> {
+pub fn build_program(program_dir: impl AsRef<Utf8Path>) -> eyre::Result<Utf8PathBuf> {
     ProgramBuilder::new(program_dir)?.run()
 }
 

--- a/crates/agglayer-elf-build/src/zkvm_build/mode.rs
+++ b/crates/agglayer-elf-build/src/zkvm_build/mode.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use eyre::Context;
 
 /// Zkvm ELF build mode.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -17,29 +17,29 @@ pub enum Mode {
 impl Mode {
     pub const DEFAULT_ENV_VAR: &str = "AGGLAYER_ELF_BUILD";
 
-    pub fn from_env_var(var: &str) -> anyhow::Result<Self> {
+    pub fn from_env_var(var: &str) -> eyre::Result<Self> {
         println!("cargo::rerun-if-env-changed={var}");
         match std::env::var(var) {
             Ok(mode_str) => mode_str.parse().context("Parsing mode env var"),
             Err(std::env::VarError::NotPresent) => Ok(Self::default()),
-            Err(err) => anyhow::bail!("Malformed mode (from {var}): {err}"),
+            Err(err) => eyre::bail!("Malformed mode (from {var}): {err}"),
         }
     }
 
-    pub fn from_env() -> anyhow::Result<Self> {
+    pub fn from_env() -> eyre::Result<Self> {
         Self::from_env_var(Self::DEFAULT_ENV_VAR)
     }
 }
 
 impl std::str::FromStr for Mode {
-    type Err = anyhow::Error;
+    type Err = eyre::Error;
 
-    fn from_str(s: &str) -> anyhow::Result<Self> {
+    fn from_str(s: &str) -> eyre::Result<Self> {
         match s.trim() {
             "build" => Ok(Self::Build),
             "refresh" | "update" => Ok(Self::Refresh),
             "" | "cached" => Ok(Self::Cached),
-            mode_str => anyhow::bail!("Unrecognized mode {mode_str:?}"),
+            mode_str => eyre::bail!("Unrecognized mode {mode_str:?}"),
         }
     }
 }

--- a/crates/agglayer-evm-client/Cargo.toml
+++ b/crates/agglayer-evm-client/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 agglayer-primitives.workspace = true
 
 alloy.workspace = true
-anyhow.workspace = true
 async-trait.workspace = true
+eyre.workspace = true
 mockall = { workspace = true, optional = true }
 thiserror.workspace = true
 

--- a/crates/agglayer-evm-client/src/get_block_hash.rs
+++ b/crates/agglayer-evm-client/src/get_block_hash.rs
@@ -19,7 +19,7 @@ pub enum GetBlockHashError {
     #[error("Getting information for block number {block_number}")]
     GettingBlock {
         block_number: u64,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
 }
 

--- a/crates/agglayer-evm-client/src/get_block_number.rs
+++ b/crates/agglayer-evm-client/src/get_block_number.rs
@@ -19,7 +19,7 @@ pub enum GetBlockNumberError {
     #[error("Getting information for block hash {block_hash}")]
     GettingBlock {
         block_hash: Digest,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
 }
 

--- a/crates/agglayer-evm-client/src/mock_rpc.rs
+++ b/crates/agglayer-evm-client/src/mock_rpc.rs
@@ -9,13 +9,13 @@ mock! {
 
     #[async_trait]
     impl GetBlockHash for Rpc {
-        type Error = anyhow::Error;
-        async fn get_block_hash(&self, block_number: u64) -> anyhow::Result<Digest>;
+        type Error = eyre::Error;
+        async fn get_block_hash(&self, block_number: u64) -> eyre::Result<Digest>;
     }
 
     #[async_trait]
     impl GetBlockNumber for Rpc {
-        type Error = anyhow::Error;
-        async fn get_block_number(&self, block_hash: Digest) -> anyhow::Result<u64>;
+        type Error = eyre::Error;
+        async fn get_block_number(&self, block_hash: Digest) -> eyre::Result<u64>;
     }
 }

--- a/crates/agglayer-interop-grpc-types/Cargo.toml
+++ b/crates/agglayer-interop-grpc-types/Cargo.toml
@@ -26,8 +26,8 @@ thiserror = { workspace = true, optional = true }
 [dev-dependencies]
 agglayer-interop-types = { workspace = true, features = ["testutils"] }
 
-anyhow.workspace = true
 bolero.workspace = true
+eyre.workspace = true
 insta.workspace = true
 rstest.workspace = true
 

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_data__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_data__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 invalid value
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_data_in_field__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_data_in_field__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 value: invalid value
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_data_in_nested__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_data_in_nested__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 data.value: invalid value
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_sig__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_sig__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 failed to parse signature
 
 Caused by:
     invalid parity: 5
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_sig_in_nested__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__bad_sig_in_nested__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 data.signature: failed to parse signature
 
 Caused by:
     invalid parity: 5
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__failed_deser__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__failed_deser__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 failed to deserialize proof
 
 Caused by:
     failed
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__failed_ser__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__failed_ser__debug.snap
@@ -1,8 +1,11 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 failed to serialize proof
 
 Caused by:
     failed
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__no_proof__debug.snap
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/snapshots/agglayer_interop_grpc_types__compat__v1__tests__no_proof__debug.snap
@@ -1,5 +1,8 @@
 ---
 source: crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
-expression: "format!(\"{:?}\", anyhow::Error::from(error))"
+expression: "format!(\"{:?}\", eyre::Error::from(error))"
 ---
 proof: required field is missing
+
+Location:
+    crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs:25:25

--- a/crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
+++ b/crates/agglayer-interop-grpc-types/src/compat/v1/tests.rs
@@ -22,7 +22,7 @@ fn error_messages(#[case] name: &str, #[case] error: Error) {
     insta::assert_debug_snapshot!(format!("{name}/kind"), error.kind());
     insta::assert_snapshot!(
         format!("{name}/debug"),
-        format!("{:?}", anyhow::Error::from(error))
+        format!("{:?}", eyre::Error::from(error))
     );
 }
 


### PR DESCRIPTION
First part of the fixes for https://github.com/agglayer/security/issues/80

BREAKING-CHANGE: Error types have been migrated to eyre in the API. No expected user-facing change unless the binary enables color-eyre.