### PR TITLE
build: update git-cliff version display

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.\n
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | split(pat="-v") | last | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\


### PR DESCRIPTION
This PR is updating git-cliff changelog generation to remove the crate type that was misleading (taking the first tag even for other crates)