### PR TITLE
feat: add vkey hashing utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,6 @@ dependencies = [
  "k256",
  "rand 0.9.2",
  "serde",
- "sp1-sdk",
  "tiny-keccak",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "k256",
  "rand 0.9.2",
  "serde",
+ "sp1-sdk",
  "tiny-keccak",
 ]
 

--- a/crates/agglayer-primitives/Cargo.toml
+++ b/crates/agglayer-primitives/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 default = ["keccak"]
 keccak = ["dep:tiny-keccak"]
 testutils = ["alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand"]
+sp1 = ["dep:sp1-sdk"]
 
 [lints]
 workspace = true
@@ -19,10 +20,11 @@ alloy-primitives.workspace = true
 arbitrary = { workspace = true, optional = true }
 byteorder.workspace = true
 derive_more.workspace = true
-k256.workspace = true
-serde.workspace = true
 hex.workspace = true
+k256.workspace = true
 rand = { workspace = true, optional = true }
+serde.workspace = true
+sp1-sdk = { workspace = true, optional = true }
 tiny-keccak = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/agglayer-primitives/Cargo.toml
+++ b/crates/agglayer-primitives/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 default = ["keccak"]
 keccak = ["dep:tiny-keccak"]
 testutils = ["alloy-primitives/arbitrary", "dep:arbitrary", "dep:rand"]
-sp1 = ["dep:sp1-sdk"]
 
 [lints]
 workspace = true
@@ -24,7 +23,6 @@ hex.workspace = true
 k256.workspace = true
 rand = { workspace = true, optional = true }
 serde.workspace = true
-sp1-sdk = { workspace = true, optional = true }
 tiny-keccak = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/agglayer-primitives/src/lib.rs
+++ b/crates/agglayer-primitives/src/lib.rs
@@ -9,6 +9,7 @@ mod digest;
 pub mod keccak;
 mod signature;
 mod utils;
+pub mod vkey_hash;
 
 pub use address::Address;
 pub use digest::Digest;

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -15,10 +15,16 @@ impl VKeyHash {
 
     pub const fn from_bytes(bytes: B256) -> Self {
         let bytes = bytes.0;
-        let mut hash_u32 = HashU32::default();
+        let mut hash_u32: HashU32 = [0; 8];
 
-        for (w, c) in bytes.chunks(4).enumerate() {
-            hash_u32[w] = u32::from_be_bytes(c.try_into().unwrap());
+        let mut w = 0_usize;
+        while w < 8 {
+            let b0 = bytes[4 * w];
+            let b1 = bytes[4 * w + 1];
+            let b2 = bytes[4 * w + 2];
+            let b3 = bytes[4 * w + 3];
+            hash_u32[w] = u32::from_be_bytes([b0, b1, b2, b3]);
+            w += 1;
         }
 
         Self(hash_u32)
@@ -32,8 +38,14 @@ impl VKeyHash {
     pub const fn to_bytes(&self) -> B256 {
         let mut bytes = [0_u8; 32];
 
-        for w in 0..8 {
-            bytes[4 * w..4 * w + 4].copy_from_slice(self.0[w].to_be_bytes());
+        let mut w = 0_usize;
+        while w < 8 {
+            let [b0, b1, b2, b3] = self.0[w].to_be_bytes();
+            bytes[4 * w] = b0;
+            bytes[4 * w + 1] = b1;
+            bytes[4 * w + 2] = b2;
+            bytes[4 * w + 3] = b3;
+            w += 1;
         }
 
         B256::new(bytes)

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -1,6 +1,10 @@
 use alloy_primitives::B256;
 use serde::{Deserialize, Serialize};
 
+use crate::Digest;
+
+/// Type alias for a 256-bit hash. When using this alias, ensure that the
+/// array is in fact hashed.
 pub type HashU32 = [u32; 8];
 
 /// Verifying key hash.
@@ -14,7 +18,7 @@ impl VKeyHash {
         Self(hash)
     }
 
-    /// Create a [`VKeyHash`] from a [`B256`]. Assumes the byte array is in
+    /// Create a [`VKeyHash`] from a [`B256`]. Assumes the bytes are in
     /// big-endian order.
     pub const fn from_bytes(bytes: B256) -> Self {
         let bytes = bytes.0;
@@ -33,7 +37,7 @@ impl VKeyHash {
         Self(hash_u32)
     }
 
-    /// Convert a [`VKeyHash`] to a [`B256`]. The resulting byte array is in
+    /// Convert a [`VKeyHash`] to a [`B256`]. The resulting bytes are in
     /// big-endian order.
     pub const fn to_bytes(&self) -> B256 {
         let mut bytes = [0_u8; 32];
@@ -54,6 +58,18 @@ impl VKeyHash {
     /// Convert a [`VKeyHash`] to a [`HashU32`].
     pub const fn to_hash_u32(&self) -> HashU32 {
         self.0
+    }
+}
+
+impl From<Digest> for VKeyHash {
+    fn from(digest: Digest) -> Self {
+        Self::from_bytes(B256::from(digest))
+    }
+}
+
+impl From<VKeyHash> for Digest {
+    fn from(hash: VKeyHash) -> Self {
+        Self::from(hash.to_bytes())
     }
 }
 

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -15,16 +15,10 @@ impl VKeyHash {
 
     pub const fn from_bytes(bytes: B256) -> Self {
         let bytes = bytes.0;
-        let mut hash_u32: HashU32 = [0; 8];
+        let mut hash_u32 = HashU32::default();
 
-        let mut w = 0_usize;
-        while w < 8 {
-            let b0 = bytes[4 * w];
-            let b1 = bytes[4 * w + 1];
-            let b2 = bytes[4 * w + 2];
-            let b3 = bytes[4 * w + 3];
-            hash_u32[w] = u32::from_be_bytes([b0, b1, b2, b3]);
-            w += 1;
+        for (w, c) in bytes.chunks(4).enumerate() {
+            hash_u32[w] = u32::from_be_bytes(c.try_into().unwrap());
         }
 
         Self(hash_u32)
@@ -38,14 +32,8 @@ impl VKeyHash {
     pub const fn to_bytes(&self) -> B256 {
         let mut bytes = [0_u8; 32];
 
-        let mut w = 0_usize;
-        while w < 8 {
-            let [b0, b1, b2, b3] = self.0[w].to_be_bytes();
-            bytes[4 * w] = b0;
-            bytes[4 * w + 1] = b1;
-            bytes[4 * w + 2] = b2;
-            bytes[4 * w + 3] = b3;
-            w += 1;
+        for w in 0..8 {
+            bytes[4 * w..4 * w + 4].copy_from_slice(self.0[w].to_be_bytes());
         }
 
         B256::new(bytes)

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -14,7 +14,8 @@ impl VKeyHash {
         Self(hash)
     }
 
-    /// Create a [`VKeyHash`] from a [`B256`]. Assumes the byte array is in big-endian order.
+    /// Create a [`VKeyHash`] from a [`B256`]. Assumes the byte array is in
+    /// big-endian order.
     pub const fn from_bytes(bytes: B256) -> Self {
         let bytes = bytes.0;
         let mut hash_u32: HashU32 = [0u32; 8];
@@ -32,7 +33,8 @@ impl VKeyHash {
         Self(hash_u32)
     }
 
-    /// Convert a [`VKeyHash`] to a [`B256`]. The resulting byte array is in big-endian order.
+    /// Convert a [`VKeyHash`] to a [`B256`]. The resulting byte array is in
+    /// big-endian order.
     pub const fn to_bytes(&self) -> B256 {
         let mut bytes = [0_u8; 32];
 

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -15,7 +15,7 @@ impl VKeyHash {
 
     pub const fn from_bytes(bytes: B256) -> Self {
         let bytes = bytes.0;
-        let mut hash_u32: HashU32 = [0; 8];
+        let mut hash_u32: HashU32 = [0u32; 8];
 
         let mut w = 0_usize;
         while w < 8 {
@@ -28,11 +28,6 @@ impl VKeyHash {
         }
 
         Self(hash_u32)
-    }
-
-    #[cfg(feature = "sp1")]
-    pub fn from_vkey<K: sp1_sdk::HashableKey>(vkey: &K) -> Self {
-        Self::from_hash_u32(vkey.hash_u32())
     }
 
     pub const fn to_bytes(&self) -> B256 {

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -1,0 +1,107 @@
+use alloy_primitives::B256;
+use serde::{Deserialize, Serialize};
+
+pub type HashU32 = [u32; 8];
+
+/// SP1 verifying key hash.
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(from = "B256", into = "B256")]
+pub struct VKeyHash(HashU32);
+
+impl VKeyHash {
+    pub const fn from_hash_u32(hash: HashU32) -> Self {
+        Self(hash)
+    }
+
+    pub const fn from_bytes(bytes: B256) -> Self {
+        let bytes = bytes.0;
+        let mut hash_u32: HashU32 = [0; 8];
+
+        let mut w = 0_usize;
+        while w < 8 {
+            let b0 = bytes[4 * w];
+            let b1 = bytes[4 * w + 1];
+            let b2 = bytes[4 * w + 2];
+            let b3 = bytes[4 * w + 3];
+            hash_u32[w] = u32::from_be_bytes([b0, b1, b2, b3]);
+            w += 1;
+        }
+
+        Self(hash_u32)
+    }
+
+    #[cfg(feature = "sp1")]
+    pub fn from_vkey<K: sp1_sdk::HashableKey>(vkey: &K) -> Self {
+        Self::from_hash_u32(vkey.hash_u32())
+    }
+
+    pub const fn to_bytes(&self) -> B256 {
+        let mut bytes = [0_u8; 32];
+
+        let mut w = 0_usize;
+        while w < 8 {
+            let [b0, b1, b2, b3] = self.0[w].to_be_bytes();
+            bytes[4 * w] = b0;
+            bytes[4 * w + 1] = b1;
+            bytes[4 * w + 2] = b2;
+            bytes[4 * w + 3] = b3;
+            w += 1;
+        }
+
+        B256::new(bytes)
+    }
+
+    pub const fn to_hash_u32(&self) -> HashU32 {
+        self.0
+    }
+}
+
+impl From<B256> for VKeyHash {
+    fn from(bytes: B256) -> Self {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl From<VKeyHash> for B256 {
+    fn from(hash: VKeyHash) -> Self {
+        hash.to_bytes()
+    }
+}
+
+impl std::str::FromStr for VKeyHash {
+    type Err = <B256 as std::str::FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self::from_bytes)
+    }
+}
+
+impl std::fmt::Debug for VKeyHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_bytes().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use alloy_primitives::b256;
+
+    use super::*;
+
+    #[test]
+    fn constructors_consistently_be() {
+        let from_hash_u32 = VKeyHash::from_hash_u32([
+            0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f, 0x10111213, 0x14151617, 0x18191a1b,
+            0x1c1d1e1f,
+        ]);
+
+        let from_hex = VKeyHash::from_bytes(b256!(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        ));
+
+        assert_eq!(from_hash_u32, from_hex);
+
+        let roundtrip = VKeyHash::from_bytes(from_hash_u32.to_bytes());
+        assert_eq!(from_hash_u32, roundtrip);
+    }
+}

--- a/crates/agglayer-primitives/src/vkey_hash.rs
+++ b/crates/agglayer-primitives/src/vkey_hash.rs
@@ -3,16 +3,18 @@ use serde::{Deserialize, Serialize};
 
 pub type HashU32 = [u32; 8];
 
-/// SP1 verifying key hash.
+/// Verifying key hash.
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(from = "B256", into = "B256")]
 pub struct VKeyHash(HashU32);
 
 impl VKeyHash {
+    /// Create a [`VKeyHash`] from a [`HashU32`].
     pub const fn from_hash_u32(hash: HashU32) -> Self {
         Self(hash)
     }
 
+    /// Create a [`VKeyHash`] from a [`B256`]. Assumes the byte array is in big-endian order.
     pub const fn from_bytes(bytes: B256) -> Self {
         let bytes = bytes.0;
         let mut hash_u32: HashU32 = [0u32; 8];
@@ -30,6 +32,7 @@ impl VKeyHash {
         Self(hash_u32)
     }
 
+    /// Convert a [`VKeyHash`] to a [`B256`]. The resulting byte array is in big-endian order.
     pub const fn to_bytes(&self) -> B256 {
         let mut bytes = [0_u8; 32];
 
@@ -46,6 +49,7 @@ impl VKeyHash {
         B256::new(bytes)
     }
 
+    /// Convert a [`VKeyHash`] to a [`HashU32`].
     pub const fn to_hash_u32(&self) -> HashU32 {
         self.0
     }


### PR DESCRIPTION
This PR adds the vkey hash operations that were originally part of the `aggkit-prover-types` crate in the `provers` repo to `agglayer-primitives`.

Partial #101