### PR TITLE
test: add `Eq`, `PartialEq` to interop types

### DIFF
--- a/crates/agglayer-interop-types/src/aggchain_proof.rs
+++ b/crates/agglayer-interop-types/src/aggchain_proof.rs
@@ -10,7 +10,7 @@ use crate::Digest;
 
 // Aggchain data submitted via the [`Certificate`].
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary, Eq, PartialEq))]
 #[serde(untagged)]
 pub enum AggchainData {
     ECDSA {
@@ -34,12 +34,12 @@ pub enum AggchainData {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary, Eq, PartialEq))]
 pub struct MultisigPayload(pub Vec<Option<Signature>>);
 
 // Aggchain proof data submitted via the Certificate.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary, Eq, PartialEq))]
 pub struct AggchainProof {
     /// proof of the aggchain proof.
     pub proof: Proof,

--- a/crates/unified-bridge/src/aggchain_proof.rs
+++ b/crates/unified-bridge/src/aggchain_proof.rs
@@ -5,7 +5,7 @@ use sha2::{Digest as Sha256Digest, Sha256};
 use crate::NetworkId;
 
 /// Public values to verify the SP1 aggchain proof.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "testutils", derive(arbitrary::Arbitrary))]
 pub struct AggchainProofPublicValues {
     /// Previous local exit root.


### PR DESCRIPTION
Gated by `testutils` as it is only intended to be used for testing and debugging.

* Related to agglayer/agglayer#989