### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agglayer-bincode"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bincode",
  "serde",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-elf-build"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-elf-build-sample-program-host"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agglayer-elf-build",
  "color-eyre",
@@ -59,14 +59,14 @@ dependencies = [
 
 [[package]]
 name = "agglayer-elf-build-sample-program-zkvm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "sp1-zkvm",
 ]
 
 [[package]]
 name = "agglayer-errors"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "eyre",
  "thiserror 2.0.18",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-evm-client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-evm-client",
  "agglayer-primitives",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-interop"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-interop-grpc-types",
  "agglayer-interop-types",
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-interop-grpc-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-bincode",
  "agglayer-interop-types",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-interop-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-bincode",
  "agglayer-interop-types",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-primitives"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-primitives",
  "alloy-primitives",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "agglayer-tries"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-primitives",
  "hex",
@@ -7915,7 +7915,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unified-bridge"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "agglayer-primitives",
  "agglayer-tries",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/*", "crates/agglayer-elf-build/sample-program/*"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/agglayer/interop"
@@ -15,14 +15,14 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 ] }
 
 [workspace.dependencies]
-agglayer-bincode = { path = "crates/agglayer-bincode", version = "0.15.0" }
-agglayer-elf-build = { path = "crates/agglayer-elf-build", version = "0.15.0" }
-agglayer-evm-client = { path = "crates/agglayer-evm-client", version = "0.15.0" }
-agglayer-interop-types = { path = "crates/agglayer-interop-types", version = "0.15.0" }
-agglayer-interop-grpc-types = { path = "crates/agglayer-interop-grpc-types", version = "0.15.0" }
-agglayer-primitives = { path = "crates/agglayer-primitives", version = "0.15.0" }
-agglayer-tries = { path = "crates/agglayer-tries", version = "0.15.0" }
-unified-bridge = { path = "crates/unified-bridge", version = "0.15.0" }
+agglayer-bincode = { path = "crates/agglayer-bincode", version = "0.16.0" }
+agglayer-elf-build = { path = "crates/agglayer-elf-build", version = "0.16.0" }
+agglayer-evm-client = { path = "crates/agglayer-evm-client", version = "0.16.0" }
+agglayer-interop-types = { path = "crates/agglayer-interop-types", version = "0.16.0" }
+agglayer-interop-grpc-types = { path = "crates/agglayer-interop-grpc-types", version = "0.16.0" }
+agglayer-primitives = { path = "crates/agglayer-primitives", version = "0.16.0" }
+agglayer-tries = { path = "crates/agglayer-tries", version = "0.16.0" }
+unified-bridge = { path = "crates/unified-bridge", version = "0.16.0" }
 
 sp1-build = "=6.2.1"
 sp1-sdk = "=6.2.1"

--- a/crates/agglayer-bincode/CHANGELOG.md
+++ b/crates/agglayer-bincode/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2026-05-19
+
+### 🐛 Bug Fixes
+
+- *(grpc)* [**breaking**] Align aggchain public_values compat with SP1 codec (#218)
+
 ## [0.9.0] - 2025-07-23
 
 ### 🚜 Refactor

--- a/crates/agglayer-elf-build/sample-program/host/Cargo.toml
+++ b/crates/agglayer-elf-build/sample-program/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agglayer-elf-build-sample-program-host"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 publish = false
 

--- a/crates/agglayer-elf-build/sample-program/zkvm/Cargo.toml
+++ b/crates/agglayer-elf-build/sample-program/zkvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agglayer-elf-build-sample-program-zkvm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 publish = false
 

--- a/crates/agglayer-interop-grpc-types/CHANGELOG.md
+++ b/crates/agglayer-interop-grpc-types/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2026-05-19
+
+### 🐛 Bug Fixes
+
+- Reject overflowing multisig signer indexes in gRPC compat decode (#217)
+- *(grpc)* [**breaking**] Align aggchain public_values compat with SP1 codec (#218)
+
 ## [0.15.0] - 2026-04-14
 
 ### 🚀 Features


### PR DESCRIPTION
Version bump type: minor
Previous version: 0.15.0
New version: 0.16.0