### PR TITLE
fix(deps): update quinn-proto and crossbeam-epoch to fix cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3004,11 +3004,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3018,11 +3016,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4923,15 +4923,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5062,6 +5063,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"


### PR DESCRIPTION
Fix the Audit CI check failing on PR and merge-queue runs.

Update two vulnerable transitive dependencies in Cargo.lock via
`cargo update -p quinn-proto -p crossbeam-epoch`:

- RUSTSEC-2026-0185: quinn-proto 0.11.14 -> 0.11.16, remote memory
  exhaustion from unbounded out-of-order stream reassembly (DoS).
  Pulled in through reqwest's optional HTTP/3 stack (lockfile entry
  only, not compiled into any target).
- RUSTSEC-2026-0204: crossbeam-epoch 0.9.18 -> 0.9.20, invalid
  pointer dereference in the `fmt::Pointer` impl. Pulled in
  through the SP1 prover stack.

Verified locally: `cargo audit` exits 0 (only allowed
informational warnings remain),
`cargo check --workspace --tests --all-features` passes, and
`cargo nextest run --workspace` passes (91/91).

Fixes #251
Fixes #255